### PR TITLE
feat(hero): 2x SDE Intern in hero subtitle

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,7 +172,7 @@
             </div>
             <div class="hero-text">
               <h1 class="hero-title">Hi, I'm <span class="highlight">Rudraksh Bhandari</span></h1>
-              <p class="hero-subtitle">SDE Intern @ AWS | CS @ UCSD</p>
+              <p class="hero-subtitle">2x SDE Intern @ AWS | CS @ UCSD</p>
               <p class="hero-description">
                 I care about building software that works well, scales thoughtfully, and actually helps people.
               </p>


### PR DESCRIPTION
Updates the hero tagline to emphasize two SDE internships at AWS, consistent with the terminal role string on the page.