### PR TITLE
fix(oura): use PR workflow instead of direct push to main

### DIFF
--- a/.github/workflows/oura-update.yml
+++ b/.github/workflows/oura-update.yml
@@ -13,6 +13,7 @@ concurrency:
 permissions:
   contents: write
   issues: write
+  pull-requests: write
 
 jobs:
   fetch-and-commit:
@@ -55,14 +56,49 @@ jobs:
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Commit and push if changed
+      - name: Create branch and PR if changed
         if: steps.check_changes.outputs.changed == 'true'
+        id: create_pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Create a unique branch name with timestamp
+          BRANCH_NAME="oura-update-$(date -u +%Y%m%d-%H%M%S)"
+          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+
+          git checkout -b "$BRANCH_NAME"
           git add oura_public.json
           git commit -m "feat(health): update Oura Ring metrics [$(date -u +%Y-%m-%d)]"
-          git push
+          git push origin "$BRANCH_NAME"
+
+          # Create PR
+          PR_URL=$(gh pr create \
+            --title "feat(health): update Oura Ring metrics [$(date -u +%Y-%m-%d)]" \
+            --body "Automated health data update from Oura Ring." \
+            --base main \
+            --head "$BRANCH_NAME")
+
+          echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
+          echo "Created PR: $PR_URL"
+
+      - name: Auto-merge PR
+        if: steps.check_changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Wait a moment for checks to potentially start
+          sleep 2
+
+          # Try to enable auto-merge (requires admin access or specific branch settings)
+          # If this fails, the PR will remain open for manual review
+          gh pr merge --auto --squash "${{ steps.create_pr.outputs.pr_url }}" 2>/dev/null || true
+
+          # If auto-merge isn't available, at least try to merge directly if we have permissions
+          # This will fail gracefully if branch protection requires reviews
+          gh pr merge --squash --delete-branch "${{ steps.create_pr.outputs.pr_url }}" 2>/dev/null || echo "PR created but requires manual review/merge due to branch protection"
 
       - name: Rotate refresh token secret (OAuth path)
         if: always() && steps.fetch_oura.outcome == 'success'


### PR DESCRIPTION
## Summary

The health dashboard workflow has been failing for days because it tried to push directly to the protected main branch. Branch protection rules require PRs for updates.

## Root Cause

GitHub Actions was failing with:
```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Required status check "checks" is expected.
```

## Changes

- Create a unique branch with timestamp for each update
- Open a PR instead of attempting direct push
- Attempt auto-merge with graceful fallback if branch protection requires manual review
- Add `pull-requests: write` permission to the workflow

## Why This Won't Break Again

1. **PR-based workflow** respects branch protection while still automating
2. **Auto-merge with fallback** - tries to auto-merge, but gracefully handles manual review requirements
3. **Unique branch names** prevent conflicts between concurrent runs
4. **Proper permissions** ensure the workflow can create PRs

## Testing

After merging, the workflow will run on its next scheduled trigger (every 15 minutes) and should successfully create PRs for health data updates.