### PR TITLE
feat: add NyaayWatch as a flagship project

### DIFF
--- a/img/nyaaywatch.svg
+++ b/img/nyaaywatch.svg
@@ -1,0 +1,30 @@
+<svg width="1200" height="800" viewBox="0 0 1200 800" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">NyaayWatch</title>
+  <desc id="desc">Editorial thumbnail for the NyaayWatch judicial observability platform.</desc>
+  <rect width="1200" height="800" fill="#F4EFE7"/>
+  <rect x="40" y="40" width="1120" height="720" rx="20" fill="#FAF7F1" stroke="#D9D1C5" stroke-width="2"/>
+  <rect x="96" y="96" width="1008" height="72" rx="12" fill="#F1EBE2" stroke="#D9D1C5" stroke-width="2"/>
+  <text x="128" y="141" fill="#152033" font-family="Georgia, 'Times New Roman', serif" font-size="42" font-weight="700">NyaayWatch</text>
+  <text x="886" y="141" fill="#5C6473" font-family="'Helvetica Neue', Arial, sans-serif" font-size="18" letter-spacing="0.12em">PUBLISHED SNAPSHOTS</text>
+  <text x="96" y="240" fill="#152033" font-family="Georgia, 'Times New Roman', serif" font-size="64" font-weight="700">District-level evidence,</text>
+  <text x="96" y="314" fill="#152033" font-family="Georgia, 'Times New Roman', serif" font-size="64" font-weight="700">methodology, and</text>
+  <text x="96" y="388" fill="#152033" font-family="Georgia, 'Times New Roman', serif" font-size="64" font-weight="700">public data surfaces.</text>
+  <text x="98" y="450" fill="#6A3D2B" font-family="'Helvetica Neue', Arial, sans-serif" font-size="22" font-weight="700" letter-spacing="0.08em">SNAPSHOT-BASED • REPRODUCIBLE • STATE-SCOPED</text>
+  <rect x="96" y="500" width="458" height="196" rx="16" fill="#FFFDFC" stroke="#D9D1C5" stroke-width="2"/>
+  <text x="124" y="542" fill="#5C6473" font-family="'Helvetica Neue', Arial, sans-serif" font-size="18" letter-spacing="0.12em">TRUST SURFACES</text>
+  <line x1="124" y1="566" x2="526" y2="566" stroke="#E2DBD0" stroke-width="2"/>
+  <text x="124" y="608" fill="#152033" font-family="'Helvetica Neue', Arial, sans-serif" font-size="28" font-weight="700">District scorecards</text>
+  <text x="124" y="648" fill="#152033" font-family="'Helvetica Neue', Arial, sans-serif" font-size="28" font-weight="700">Evidence pages and exports</text>
+  <text x="124" y="688" fill="#152033" font-family="'Helvetica Neue', Arial, sans-serif" font-size="28" font-weight="700">Methodology and API</text>
+  <rect x="586" y="500" width="518" height="196" rx="16" fill="#FFFDFC" stroke="#D9D1C5" stroke-width="2"/>
+  <text x="614" y="542" fill="#5C6473" font-family="'Helvetica Neue', Arial, sans-serif" font-size="18" letter-spacing="0.12em">PUBLIC SURFACES</text>
+  <line x1="614" y1="566" x2="1076" y2="566" stroke="#E2DBD0" stroke-width="2"/>
+  <rect x="614" y="594" width="148" height="72" rx="12" fill="#EEF2F7"/>
+  <rect x="778" y="594" width="148" height="72" rx="12" fill="#F3EEE7"/>
+  <rect x="942" y="594" width="134" height="72" rx="12" fill="#EEF2F7"/>
+  <text x="655" y="638" fill="#152033" font-family="'Helvetica Neue', Arial, sans-serif" font-size="26" font-weight="700">HP</text>
+  <text x="819" y="638" fill="#152033" font-family="'Helvetica Neue', Arial, sans-serif" font-size="26" font-weight="700">PB</text>
+  <text x="981" y="638" fill="#152033" font-family="'Helvetica Neue', Arial, sans-serif" font-size="26" font-weight="700">TN</text>
+  <line x1="614" y1="692" x2="1076" y2="692" stroke="#E2DBD0" stroke-width="2"/>
+  <text x="614" y="730" fill="#5C6473" font-family="'Helvetica Neue', Arial, sans-serif" font-size="22">Scorecards • Evidence • Exports • API</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -386,7 +386,7 @@
           <!-- Project images (stacked, crossfaded) -->
           <div class="projects__images" aria-hidden="true">
             <img
-              src="img/nomnom.png?v=2"
+              src="img/nyaaywatch.svg?v=1"
               alt=""
               class="projects__img"
               data-project="0"
@@ -394,7 +394,7 @@
               decoding="async"
             />
             <img
-              src="img/outfitr-placeholder.svg?v=1"
+              src="img/nomnom.png?v=2"
               alt=""
               class="projects__img"
               data-project="1"
@@ -402,7 +402,7 @@
               decoding="async"
             />
             <img
-              src="img/ShareAllBooks.jpg?v=1"
+              src="img/outfitr-placeholder.svg?v=1"
               alt=""
               class="projects__img"
               data-project="2"
@@ -410,19 +410,27 @@
               decoding="async"
             />
             <img
-              src="img/sapphix-placeholder.svg?v=1"
+              src="img/ShareAllBooks.jpg?v=1"
               alt=""
               class="projects__img"
               data-project="3"
               loading="lazy"
               decoding="async"
             />
-            <img src="img/dbc.svg?v=1" alt="" class="projects__img" data-project="4" loading="lazy" decoding="async" />
+            <img
+              src="img/sapphix-placeholder.svg?v=1"
+              alt=""
+              class="projects__img"
+              data-project="4"
+              loading="lazy"
+              decoding="async"
+            />
+            <img src="img/dbc.svg?v=1" alt="" class="projects__img" data-project="5" loading="lazy" decoding="async" />
             <img
               src="img/health-dashboard.png?v=1"
               alt=""
               class="projects__img"
-              data-project="5"
+              data-project="6"
               loading="lazy"
               decoding="async"
             />
@@ -430,17 +438,46 @@
               src="img/vibe-tracker.svg?v=1"
               alt=""
               class="projects__img"
-              data-project="6"
+              data-project="7"
               loading="lazy"
               decoding="async"
             />
-            <img src="img/poc.png?v=1" alt="" class="projects__img" data-project="7" loading="lazy" decoding="async" />
+            <img src="img/poc.png?v=1" alt="" class="projects__img" data-project="8" loading="lazy" decoding="async" />
           </div>
 
           <!-- Project info cards -->
           <div class="projects__cards">
-            <!-- 1. NomNom -->
+            <!-- 1. NyaayWatch -->
             <article class="proj-card" data-project="0">
+              <h3 class="proj-card__title">NyaayWatch</h3>
+              <p class="proj-card__desc">
+                Built an evidence-first platform for making Indian court backlog and district-level judicial performance
+                legible to the public. A public-interest judicial observability platform that turns published Indian
+                court-system snapshots into clear, district-level evidence, methodology, and public data surfaces. Ships
+                district scorecards, evidence pages, exports, and explicit state-scoped public surfaces across multiple
+                Indian states, backed by a reproducible snapshot pipeline with operator-controlled publish, replay, and
+                rollback on Node.js, TypeScript, PostgreSQL, S3, and AWS. Public site at
+                <a href="https://nyaaywatch.in" target="_blank" rel="noopener noreferrer" class="text-link"
+                  >nyaaywatch.in</a
+                >, source on
+                <a
+                  href="https://github.com/rudrakshbhandari/nyaaywatch"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-link"
+                  >GitHub</a
+                >.
+              </p>
+              <div class="proj-card__tech">
+                <span>Node.js</span><span>TypeScript</span><span>PostgreSQL</span><span>AWS</span>
+              </div>
+              <a href="https://nyaaywatch.in" target="_blank" rel="noopener noreferrer" class="proj-card__link"
+                >Visit nyaaywatch.in →</a
+              >
+            </article>
+
+            <!-- 2. NomNom -->
+            <article class="proj-card" data-project="1">
               <h3 class="proj-card__title">NomNom</h3>
               <p class="proj-card__desc">
                 UCSD-exclusive delivery startup connecting students with dining hall couriers. UCSD-only authentication,
@@ -453,8 +490,8 @@
               >
             </article>
 
-            <!-- 2. Outfitr -->
-            <article class="proj-card" data-project="1">
+            <!-- 3. Outfitr -->
+            <article class="proj-card" data-project="2">
               <h3 class="proj-card__title">Outfitr <span class="proj-card__badge">Launching soon</span></h3>
               <p class="proj-card__desc">
                 Built Outfitr, an AI-powered fashion discovery platform that aggregates multi-retailer catalogs and
@@ -475,8 +512,8 @@
               >
             </article>
 
-            <!-- 3. ShareAllBooks -->
-            <article class="proj-card" data-project="2">
+            <!-- 4. ShareAllBooks -->
+            <article class="proj-card" data-project="3">
               <h3 class="proj-card__title">ShareAllBooks</h3>
               <p class="proj-card__desc">
                 2k+ installs, 1.5k+ transactions,
@@ -495,8 +532,8 @@
               >
             </article>
 
-            <!-- 4. Sapphix -->
-            <article class="proj-card" data-project="3">
+            <!-- 5. Sapphix -->
+            <article class="proj-card" data-project="4">
               <h3 class="proj-card__title">Sapphix <span class="proj-card__badge">Launching soon</span></h3>
               <p class="proj-card__desc">
                 Women-only proximity dating app — solo-built full-stack MVP. Designed and implemented a full-stack
@@ -509,8 +546,8 @@
               </div>
             </article>
 
-            <!-- 5. David Brower Center -->
-            <article class="proj-card" data-project="4">
+            <!-- 6. David Brower Center -->
+            <article class="proj-card" data-project="5">
               <h3 class="proj-card__title">David Brower Center</h3>
               <p class="proj-card__desc">
                 Database platform for nonprofit organizations to visualize relationships between NPOs. Full-stack
@@ -530,8 +567,8 @@
               >
             </article>
 
-            <!-- 6. Health Dashboard -->
-            <article class="proj-card" data-project="5">
+            <!-- 7. Health Dashboard -->
+            <article class="proj-card" data-project="6">
               <h3 class="proj-card__title">Health Metrics Dashboard</h3>
               <p class="proj-card__desc">
                 Personal health analytics dashboard with automated Oura Ring data pipeline. Built a live dashboard that
@@ -545,8 +582,8 @@
               <a href="/health/" class="proj-card__link">View dashboard →</a>
             </article>
 
-            <!-- 7. Vibe Tracker -->
-            <article class="proj-card" data-project="6">
+            <!-- 8. Vibe Tracker -->
+            <article class="proj-card" data-project="7">
               <h3 class="proj-card__title">Vibe Tracker</h3>
               <p class="proj-card__desc">
                 Built a Next.js and TypeScript analytics platform for GitHub productivity tracking. Aggregates GitHub
@@ -565,8 +602,8 @@
               >
             </article>
 
-            <!-- 8. Psyches of Color -->
-            <article class="proj-card" data-project="7">
+            <!-- 9. Psyches of Color -->
+            <article class="proj-card" data-project="8">
               <h3 class="proj-card__title">Psyches of Color</h3>
               <p class="proj-card__desc">
                 Psyches of Color develops a mental health app serving underserved communities. Full-stack development


### PR DESCRIPTION
## Summary
- add NyaayWatch as the lead project in the portfolio projects section
- use current shipped-state copy aligned with the site voice and NyaayWatch source-of-truth docs
- add a restrained SVG showcase image for the pinned project preview

## Verification
- served the site locally with `python3 -m http.server 4173`
- verified the projects section visually in Playwright against the running site