### PR TITLE
fix: sync project image on fast scroll

### DIFF
--- a/js/animations.js
+++ b/js/animations.js
@@ -219,26 +219,50 @@ function initExperienceScene() {
    Image crossfade as project cards scroll into view
    =========================== */
 function initProjectsScene() {
+  var section = document.querySelector('.scene--projects');
   var images = document.querySelectorAll('.projects__img');
   var cards = document.querySelectorAll('.proj-card');
 
-  if (!images.length || !cards.length) return;
+  if (!section || !images.length || !cards.length) return;
 
-  images[0].classList.add('active');
-  cards[0].classList.add('active');
+  var activeProjectIndex = -1;
 
-  cards.forEach(function (card) {
-    ScrollTrigger.create({
-      trigger: card,
-      start: 'top 60%',
-      end: 'bottom 40%',
-      onEnter: function () {
-        activateProject(card, images, cards);
-      },
-      onEnterBack: function () {
-        activateProject(card, images, cards);
-      },
+  function syncActiveProject() {
+    var viewportMid = window.innerHeight * 0.5;
+    var bestIndex = 0;
+    var bestDistance = Infinity;
+
+    cards.forEach(function (card, index) {
+      var rect = card.getBoundingClientRect();
+      var cardCenter = rect.top + rect.height / 2;
+      var distance = Math.abs(cardCenter - viewportMid);
+
+      if (distance < bestDistance) {
+        bestDistance = distance;
+        bestIndex = index;
+      }
     });
+
+    if (bestIndex !== activeProjectIndex) {
+      activeProjectIndex = bestIndex;
+      activateProject(cards[bestIndex], images, cards);
+    }
+  }
+
+  syncActiveProject();
+
+  ScrollTrigger.create({
+    trigger: section,
+    start: 'top top',
+    end: 'bottom bottom',
+    onEnter: syncActiveProject,
+    onEnterBack: syncActiveProject,
+    onUpdate: syncActiveProject,
+    onRefresh: syncActiveProject,
+    onLeaveBack: function () {
+      activeProjectIndex = 0;
+      activateProject(cards[0], images, cards);
+    },
   });
 }
 


### PR DESCRIPTION
## Summary\n- Derive the active project image from the current scroll position instead of relying only on per-card enter events\n- Reset to NyaayWatch when scrolling back up quickly through the projects section\n\n## Verification\n- 
> rudraksh-portfolio@1.0.0 check:syntax
> sh -c 'set -- js/*.js scripts/*.mjs *.mjs; for f in "$@"; do [ -e "$f" ] || continue; node --check "$f"; done'\n- Browser probe: fast scroll down to NomNom region, then fast scroll back up; active project returned to NyaayWatch