### PR TITLE
fix(mobile): touch scrolling and safe-area layout

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -33,6 +33,7 @@ html {
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
   scroll-behavior: smooth;
+  scroll-padding-top: 5.5rem;
 }
 
 ::selection {
@@ -49,6 +50,8 @@ body {
   overflow-x: hidden;
   opacity: 0;
   transition: opacity 0.5s var(--ease-smooth);
+  padding-left: env(safe-area-inset-left, 0px);
+  padding-right: env(safe-area-inset-right, 0px);
 }
 
 body.loaded {
@@ -116,6 +119,7 @@ button:focus-visible {
   left: 0;
   right: 0;
   z-index: 1000;
+  padding-top: env(safe-area-inset-top, 0px);
   background: rgba(245, 240, 235, 0.85);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
@@ -878,11 +882,27 @@ button:focus-visible {
 
 /* Tablet (768px) */
 @media (max-width: 768px) {
+  /* Hero: drop the extra 180vh “scroll runway” used for desktop pin; fill one stable viewport instead */
+  .scene--hero {
+    height: auto;
+    min-height: 100vh;
+    min-height: 100svh;
+    padding-bottom: 2.5rem;
+  }
+
+  .hero__inner {
+    min-height: 100vh;
+    min-height: 100svh;
+    height: auto;
+    overflow: visible;
+    padding: 4.75rem 1.25rem 2rem;
+  }
+
   /* Nav */
   .nav-menu {
     position: fixed;
     left: -100%;
-    top: 60px;
+    top: calc(60px + env(safe-area-inset-top, 0px));
     flex-direction: column;
     background: rgba(245, 240, 235, 0.98);
     width: 100%;

--- a/health/index.html
+++ b/health/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content="Health Metrics - Oura Ring Data | Rudraksh Bhandari" />
     <meta name="author" content="Rudraksh Bhandari" />
     <meta
@@ -84,6 +84,7 @@
         color: var(--text-primary);
         background: var(--background-dark);
         min-height: 100vh;
+        min-height: 100dvh;
         overflow-x: hidden;
       }
 
@@ -114,7 +115,8 @@
       .nav-container {
         max-width: 1200px;
         margin: 0 auto;
-        padding: 1rem 1.5rem;
+        padding: calc(1rem + env(safe-area-inset-top, 0px)) calc(1.5rem + env(safe-area-inset-right, 0px)) 1rem
+          calc(1.5rem + env(safe-area-inset-left, 0px));
         display: flex;
         align-items: center;
         justify-content: space-between;
@@ -148,7 +150,7 @@
       main {
         max-width: 1200px;
         margin: 0 auto;
-        padding: 7rem 1.5rem 4rem;
+        padding: 7rem calc(1.5rem + env(safe-area-inset-right, 0px)) 4rem calc(1.5rem + env(safe-area-inset-left, 0px));
       }
 
       .page-header {
@@ -700,6 +702,7 @@
         width: 100%;
         height: 220px;
         display: block;
+        touch-action: pan-y;
       }
 
       .timeline-axis-label {
@@ -1042,7 +1045,8 @@
       footer {
         max-width: 1200px;
         margin: 0 auto;
-        padding: 2rem 1.5rem;
+        padding: 2rem calc(1.5rem + env(safe-area-inset-right, 0px)) calc(2rem + env(safe-area-inset-bottom, 0px))
+          calc(1.5rem + env(safe-area-inset-left, 0px));
         border-top: 1px solid var(--border-color);
         display: flex;
         flex-wrap: wrap;
@@ -1151,6 +1155,7 @@
         align-items: flex-end;
         gap: 0.5rem;
         height: 100%;
+        overscroll-behavior-x: contain;
       }
 
       .trend-day {
@@ -1319,6 +1324,34 @@
           font-size: 2rem;
         }
 
+        main {
+          padding-top: calc(5.5rem + env(safe-area-inset-top, 0px));
+          padding-bottom: calc(2.75rem + env(safe-area-inset-bottom, 0px));
+        }
+
+        .page-header {
+          margin-bottom: 2rem;
+        }
+
+        .nav-logo a {
+          font-size: 1.1rem;
+        }
+
+        .nav-back {
+          min-height: 44px;
+          padding: 0.4rem 0.6rem;
+          align-items: center;
+          -webkit-tap-highlight-color: transparent;
+        }
+
+        .metric-card {
+          padding: 1.25rem;
+        }
+
+        .timeline-svg {
+          height: 200px;
+        }
+
         .timeline-stats {
           grid-template-columns: repeat(2, minmax(0, 1fr));
         }
@@ -1350,9 +1383,11 @@
           padding-bottom: 0.5rem;
           -webkit-overflow-scrolling: touch;
           height: 140px;
+          touch-action: pan-x pan-y;
         }
 
         .trend-day {
+          flex: 0 0 auto;
           min-width: 44px;
         }
 

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content="Rudraksh Bhandari - Portfolio Website" />
     <meta name="keywords" content="portfolio, developer, software engineer, web developer" />
     <meta name="author" content="Rudraksh Bhandari" />

--- a/js/health.js
+++ b/js/health.js
@@ -788,13 +788,43 @@ function renderHeartRateTimeline(series, data) {
     svgEl.onmousemove = e => findNearestAndUpdate(e.clientX, e.clientY);
     svgEl.onmouseleave = hideTracking;
 
-    // Touch support for mobile
-    svgEl.ontouchmove = e => {
-      e.preventDefault();
-      const touch = e.touches[0];
-      findNearestAndUpdate(touch.clientX, touch.clientY);
+    // Mobile: only hijack the gesture when the user is clearly scrubbing horizontally.
+    // Unconditional preventDefault on touchmove made vertical page scroll almost impossible on the chart.
+    let hrTouchStart = null;
+    let hrTouchMode = null;
+    const HR_GESTURE_PX = 12;
+
+    svgEl.ontouchstart = e => {
+      if (e.touches.length !== 1) return;
+      const t = e.touches[0];
+      hrTouchStart = { x: t.clientX, y: t.clientY };
+      hrTouchMode = null;
     };
-    svgEl.ontouchend = hideTracking;
+
+    svgEl.ontouchmove = e => {
+      if (!hrTouchStart || e.touches.length !== 1) return;
+      const t = e.touches[0];
+      const dx = t.clientX - hrTouchStart.x;
+      const dy = t.clientY - hrTouchStart.y;
+
+      if (hrTouchMode === null) {
+        if (Math.abs(dx) < HR_GESTURE_PX && Math.abs(dy) < HR_GESTURE_PX) return;
+        hrTouchMode = Math.abs(dy) > Math.abs(dx) + 4 ? 'scroll' : 'scrub';
+      }
+
+      if (hrTouchMode === 'scrub') {
+        e.preventDefault();
+        findNearestAndUpdate(t.clientX, t.clientY);
+      }
+    };
+
+    const endHrTouch = () => {
+      hrTouchStart = null;
+      hrTouchMode = null;
+      hideTracking();
+    };
+    svgEl.ontouchend = endHrTouch;
+    svgEl.ontouchcancel = endHrTouch;
   }
 
   const minEl = document.getElementById('heart-rate-min');


### PR DESCRIPTION
## Summary

Mobile usability fixes for the health dashboard and the main portfolio.

### Health (`/health`)
- **Heart rate chart:** Touch handlers previously called `preventDefault()` on every `touchmove`, which blocked vertical page scrolling whenever a finger touched the SVG. Gesture detection now treats mostly-vertical movement as scroll and only captures horizontal scrubbing.
- **Layout:** `viewport-fit=cover`, safe-area padding on header/main/footer, `100dvh` min-height, slightly shorter chart height on small screens, and a proper 44px minimum tap target for the back link.
- **7-day trends:** Horizontal scroll strip uses `touch-action: pan-x pan-y` and `overscroll-behavior-x: contain` so nested scrolling behaves more predictably.

### Portfolio (home)
- **Hero:** On viewports ≤768px, the hero no longer uses the desktop `180vh` scroll runway (meant for pinned GSAP). It sizes to `min-height: 100svh` with content-driven height so mobile scrolling feels natural.
- **Safe areas:** Navbar respects the top inset; mobile menu offset matches the full bar height including the inset.
- **Anchors:** `scroll-padding-top` helps in-page hash links clear the fixed nav.