### PR TITLE
fix(homepage): mobile navigation, scroll, and safe-area layout

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -33,6 +33,7 @@ html {
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
   scroll-behavior: smooth;
+  scroll-padding-top: calc(4.75rem + env(safe-area-inset-top, 0px));
 }
 
 ::selection {
@@ -53,6 +54,13 @@ body {
 
 body.loaded {
   opacity: 1;
+}
+
+/* Prevent background scroll while mobile nav drawer is open */
+html.nav-menu-open,
+body.nav-menu-open {
+  overflow: hidden;
+  touch-action: none;
 }
 
 img {
@@ -116,6 +124,7 @@ button:focus-visible {
   left: 0;
   right: 0;
   z-index: 1000;
+  padding-top: env(safe-area-inset-top, 0px);
   background: rgba(245, 240, 235, 0.85);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
@@ -219,7 +228,12 @@ button:focus-visible {
   cursor: pointer;
   background: none;
   border: none;
-  padding: 4px;
+  padding: 0;
+  min-width: 44px;
+  min-height: 44px;
+  align-items: center;
+  justify-content: center;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .bar {
@@ -1120,7 +1134,7 @@ button:focus-visible {
   background: var(--color-text);
   color: rgba(255, 255, 255, 0.5);
   text-align: center;
-  padding: 1.5rem 2rem;
+  padding: 1.5rem 2rem calc(1.5rem + env(safe-area-inset-bottom, 0px));
   font-size: 0.8rem;
   font-family: var(--font-display);
   letter-spacing: 0.03em;
@@ -1149,24 +1163,70 @@ button:focus-visible {
 
 /* Tablet (768px) */
 @media (max-width: 768px) {
-  /* Nav */
+  /* Hero: one stable viewport instead of 180vh desktop scroll runway */
+  .scene--hero {
+    height: auto;
+    min-height: 100vh;
+    min-height: 100svh;
+    padding-bottom: 2.5rem;
+  }
+
+  .hero__inner {
+    min-height: 100vh;
+    min-height: 100svh;
+    height: auto;
+    overflow: visible;
+    padding: 4.75rem 1.25rem 2rem;
+  }
+
+  .hero__name {
+    gap: 0.2rem;
+  }
+
+  .nav-container {
+    padding-left: calc(1rem + env(safe-area-inset-left, 0px));
+    padding-right: calc(1rem + env(safe-area-inset-right, 0px));
+  }
+
+  /* Nav drawer: full height, scrollable list, clears home-indicator */
   .nav-menu {
     position: fixed;
     left: -100%;
-    top: 60px;
+    right: 0;
+    top: calc(60px + env(safe-area-inset-top, 0px));
+    bottom: 0;
+    width: 100%;
     flex-direction: column;
     background: rgba(245, 240, 235, 0.98);
-    width: 100%;
     text-align: center;
     transition: left 0.3s var(--ease-smooth);
-    padding: 2rem 0;
-    gap: 1.25rem;
+    padding: 1.5rem 0 calc(2rem + env(safe-area-inset-bottom, 0px));
+    gap: 0.25rem;
     backdrop-filter: blur(16px);
     -webkit-backdrop-filter: blur(16px);
+    overflow-x: hidden;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior: contain;
+    box-shadow: 0 12px 40px rgba(26, 26, 26, 0.08);
+    z-index: 999;
   }
 
   .nav-menu.active {
     left: 0;
+  }
+
+  .nav-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 48px;
+    padding: 0.5rem 1.25rem;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .nav-resume {
+    margin-top: 0.25rem;
   }
 
   .nav-toggle {
@@ -1205,6 +1265,8 @@ button:focus-visible {
   .about__container {
     grid-template-columns: 1fr;
     gap: 2rem;
+    padding-left: calc(1.25rem + env(safe-area-inset-left, 0px));
+    padding-right: calc(1.25rem + env(safe-area-inset-right, 0px));
   }
 
   .about__photo-sticky {
@@ -1223,10 +1285,14 @@ button:focus-visible {
     gap: 2rem;
   }
 
+  .experience__header {
+    padding: 5rem calc(1.5rem + env(safe-area-inset-left, 0px)) 1.5rem calc(1.5rem + env(safe-area-inset-right, 0px));
+  }
+
   /* Experience: vertical layout on mobile */
   .experience__track {
     flex-direction: column;
-    padding: 2rem 1.5rem;
+    padding: 2rem calc(1.25rem + env(safe-area-inset-left, 0px)) 2rem calc(1.25rem + env(safe-area-inset-right, 0px));
     gap: 1.5rem;
   }
 
@@ -1252,7 +1318,7 @@ button:focus-visible {
   }
 
   .projects__cards {
-    padding: 2rem 1.5rem;
+    padding: 2rem calc(1.1rem + env(safe-area-inset-left, 0px)) 2rem calc(1.1rem + env(safe-area-inset-right, 0px));
   }
 
   .projects__intro {
@@ -1288,29 +1354,87 @@ button:focus-visible {
     aspect-ratio: 16 / 10;
   }
 
+  .proj-card__link {
+    display: inline-flex;
+    align-items: center;
+    min-height: 44px;
+    padding: 0.4rem 0;
+    margin: 0.15rem 0;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .scene--skills {
+    padding-left: calc(1.5rem + env(safe-area-inset-left, 0px));
+    padding-right: calc(1.5rem + env(safe-area-inset-right, 0px));
+  }
+
+  .skills__prose {
+    text-align: left;
+    font-size: 1rem;
+    hyphens: auto;
+  }
+
   /* Contact */
+  .scene--contact {
+    min-height: 100svh;
+    padding: calc(3.5rem + env(safe-area-inset-top, 0px)) calc(1.25rem + env(safe-area-inset-left, 0px))
+      calc(3.5rem + env(safe-area-inset-bottom, 0px)) calc(1.25rem + env(safe-area-inset-right, 0px));
+  }
+
+  .contact__inner {
+    padding: 0;
+    max-width: 100%;
+  }
+
+  .contact__email {
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    line-height: 1.2;
+    padding: 0.25rem;
+    -webkit-tap-highlight-color: transparent;
+  }
+
   .contact__socials {
     flex-direction: column;
-    gap: 1rem;
+    gap: 0.5rem;
+    align-items: stretch;
+  }
+
+  .contact__social-link {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 48px;
+    padding: 0.5rem 1rem;
+    opacity: 1;
+    border-radius: 6px;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .contact__social-link:active {
+    background: rgba(255, 255, 255, 0.12);
   }
 }
 
 /* Small mobile (480px) */
 @media (max-width: 480px) {
   .nav-container {
-    padding: 0 1rem;
+    padding-left: calc(1rem + env(safe-area-inset-left, 0px));
+    padding-right: calc(1rem + env(safe-area-inset-right, 0px));
   }
 
   .about__container {
-    padding: 0 1rem;
+    padding-left: calc(1rem + env(safe-area-inset-left, 0px));
+    padding-right: calc(1rem + env(safe-area-inset-right, 0px));
   }
 
   .experience__header {
-    padding: 4rem 1rem 1.5rem;
+    padding: 4rem calc(1rem + env(safe-area-inset-left, 0px)) 1.5rem calc(1rem + env(safe-area-inset-right, 0px));
   }
 
   .projects__cards {
-    padding: 2rem 1rem;
+    padding: 2rem calc(0.9rem + env(safe-area-inset-left, 0px)) 2rem calc(0.9rem + env(safe-area-inset-right, 0px));
   }
 
   .projects__meta-links {
@@ -1377,6 +1501,7 @@ button:focus-visible {
   .scene--hero {
     height: auto;
     min-height: 100vh;
+    min-height: 100svh;
   }
 
   .hero__inner {

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta
       name="description"
       content="ML researcher at UC San Diego building consumer and public-interest software across mobile products, AI systems, and civic data."

--- a/js/main.js
+++ b/js/main.js
@@ -15,6 +15,13 @@ document.addEventListener('DOMContentLoaded', function () {
   initProjectImageCrossfade();
 });
 
+/** Pixels to leave clear below the fixed navbar (includes safe-area padding on notched devices). */
+function getFixedNavOffset() {
+  var navbar = document.getElementById('navbar');
+  if (!navbar) return 60;
+  return navbar.offsetHeight;
+}
+
 /* ===========================
    Dev Mode
    =========================== */
@@ -70,7 +77,7 @@ function initNavigation() {
         e.preventDefault();
         var targetSection = document.querySelector(targetId);
         if (targetSection) {
-          var offsetTop = targetSection.offsetTop - 60;
+          var offsetTop = targetSection.offsetTop - getFixedNavOffset();
           window.scrollTo({ top: offsetTop, behavior: 'smooth' });
         }
       }
@@ -111,25 +118,42 @@ function initMobileMenu() {
 
   if (!navToggle || !navMenu) return;
 
+  function setNavMenuOpen(open) {
+    document.documentElement.classList.toggle('nav-menu-open', open);
+    document.body.classList.toggle('nav-menu-open', open);
+  }
+
+  function closeNavMenu() {
+    navMenu.classList.remove('active');
+    navToggle.classList.remove('active');
+    navToggle.setAttribute('aria-expanded', 'false');
+    setNavMenuOpen(false);
+  }
+
   navToggle.addEventListener('click', function () {
     var isExpanded = navMenu.classList.toggle('active');
     navToggle.classList.toggle('active');
     navToggle.setAttribute('aria-expanded', isExpanded);
+    setNavMenuOpen(isExpanded);
   });
 
   navLinks.forEach(function (link) {
     link.addEventListener('click', function () {
-      navMenu.classList.remove('active');
-      navToggle.classList.remove('active');
-      navToggle.setAttribute('aria-expanded', 'false');
+      closeNavMenu();
     });
   });
 
   document.addEventListener('click', function (e) {
     if (!navToggle.contains(e.target) && !navMenu.contains(e.target)) {
-      navMenu.classList.remove('active');
-      navToggle.classList.remove('active');
-      navToggle.setAttribute('aria-expanded', 'false');
+      if (navMenu.classList.contains('active')) {
+        closeNavMenu();
+      }
+    }
+  });
+
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape' && navMenu.classList.contains('active')) {
+      closeNavMenu();
     }
   });
 }


### PR DESCRIPTION
## Context

Targets the **main portfolio** (not the health dashboard): improves how the site feels on phone-sized viewports.

## What changed

- **No more background scroll** while the hamburger menu is open; **Escape** closes the drawer.
- **In-page links** (nav + dot nav) scroll with an offset derived from the **actual fixed header height**, so sections are not hidden under the bar on notched devices.
- **Hero:** uses `100svh` and content-driven height on ≤768px instead of the desktop `180vh` scroll runway used for GSAP pin.
- **Nav drawer:** fills the space below the header, scrolls if needed, respects **safe-area** bottom, and uses **overscroll-behavior** to reduce scroll chaining.
- **Touch targets:** hamburger ≥44px, nav links and contact actions **48px** min height, project "View …" links **44px** min height.
- **Contact:** email can **wrap** (`overflow-wrap: anywhere`) instead of `nowrap` overflow.
- **Skills:** prose **left-aligned** on small screens for easier reading.
- **viewport-fit=cover** + **env(safe-area-inset\*)** on navbar, section gutters, and footer.

## How to verify

Open the PR **Cloudflare Pages preview** at iPhone width: menu should not let the page drift underneath; tap targets should feel comfortable; contact block should not force horizontal scroll.