### PR TITLE
fix(oura): restore scheduled workflow (invalid step if)

### DIFF
--- a/.github/workflows/oura-update.yml
+++ b/.github/workflows/oura-update.yml
@@ -35,10 +35,15 @@ jobs:
         with:
           token: ${{ secrets.OURA_SECRET_UPDATE_TOKEN != '' && secrets.OURA_SECRET_UPDATE_TOKEN || secrets.GITHUB_TOKEN }}
 
+      # GitHub forbids `secrets` in step `if:` — that made the whole workflow invalid and
+      # stopped schedule + workflow_dispatch. Use env + bash instead.
       - name: Warn if Oura PAT missing for PR merges
-        if: secrets.OURA_SECRET_UPDATE_TOKEN == ''
+        env:
+          OURA_PAT_CONFIGURED: ${{ secrets.OURA_SECRET_UPDATE_TOKEN != '' && 'yes' || 'no' }}
         run: |
-          echo "::warning::OURA_SECRET_UPDATE_TOKEN is not set. PRs opened with GITHUB_TOKEN do not trigger pull_request workflows (GitHub restriction), so required checks never run and merges stall. Set OURA_SECRET_UPDATE_TOKEN to the same PAT you use for gh secret set (repo Contents + Pull requests)."
+          if [ "${OURA_PAT_CONFIGURED}" != "yes" ]; then
+            echo "::warning::OURA_SECRET_UPDATE_TOKEN is not set. PRs opened with GITHUB_TOKEN do not trigger pull_request workflows (GitHub restriction), so required checks never run and merges stall. Set OURA_SECRET_UPDATE_TOKEN to the same PAT you use for gh secret set (repo Contents + Pull requests)."
+          fi
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/docs/OURA_AUTOMATION.md
+++ b/docs/OURA_AUTOMATION.md
@@ -22,6 +22,8 @@ The scheduled workflow opens a PR when `oura_public.json` changes. **Do not use 
 
 **Fix:** set repo secret `OURA_SECRET_UPDATE_TOKEN` to a Personal Access Token with access to this repository (same PAT already used for `gh secret set` / refresh-token rotation). The workflow uses it for `actions/checkout`, `git push`, `gh pr create`, and merge polling so PRs behave like human-opened PRs, CI runs, and squash-merge can complete.
 
+**Do not use `secrets` in step `if:`** in Actions YAML — GitHub rejects the workflow (schedule and `workflow_dispatch` stop entirely). Use `env:` with an expression and check in the shell instead.
+
 ## Current Recovery Behavior
 
 - If a local refresh token is stale, `scripts/fetch_oura_and_write_json.mjs` now starts a browser OAuth recovery flow automatically.


### PR DESCRIPTION
## Cause

Step `if: secrets.OURA_SECRET_UPDATE_TOKEN == ''` is **invalid** in GitHub Actions: the `secrets` context is not allowed in step-level `if` expressions. The workflow file fails validation, so **cron and workflow_dispatch both stop** (HTTP 422 on dispatch).

## Fix

Drive the warning from `env:` + bash instead.

## Verification

After merge: `gh workflow run oura-update.yml --ref main` should succeed.