### PR TITLE
Sharpen homepage positioning for reviewer skim

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -294,6 +294,32 @@ button:focus-visible {
   color: var(--color-white);
 }
 
+.section-kicker {
+  font-family: var(--font-display);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-accent);
+  margin-bottom: 1rem;
+}
+
+.section-kicker--light {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.section-intro {
+  max-width: 42rem;
+  font-size: 1rem;
+  line-height: 1.75;
+  color: var(--color-muted);
+  margin-top: 1rem;
+}
+
+.section-intro--light {
+  color: rgba(255, 255, 255, 0.7);
+}
+
 /* =============================================
    SCENE 1: HERO
    ============================================= */
@@ -310,6 +336,17 @@ button:focus-visible {
   align-items: center;
   justify-content: center;
   overflow: hidden;
+}
+
+.hero__eyebrow {
+  font-family: var(--font-display);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-accent);
+  margin-bottom: 1.5rem;
+  text-align: center;
 }
 
 .hero__name {
@@ -661,6 +698,41 @@ button:focus-visible {
   padding: 6rem 3rem 6rem 2rem;
 }
 
+.projects__intro {
+  padding: 0 0 2rem;
+  border-bottom: 1px solid rgba(26, 26, 26, 0.08);
+}
+
+.projects__heading {
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: clamp(2rem, 4vw, 3.25rem);
+  line-height: 1.05;
+  color: var(--color-text);
+  max-width: 15ch;
+}
+
+.projects__meta-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.projects__meta-link {
+  font-family: var(--font-display);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-accent);
+  transition: color 0.2s ease;
+}
+
+.projects__meta-link:hover {
+  color: var(--color-text);
+}
+
 .proj-card {
   padding: 4rem 0;
   border-bottom: 1px solid rgba(26, 26, 26, 0.08);
@@ -922,6 +994,12 @@ button:focus-visible {
     font-size: clamp(2.8rem, 11vw, 5rem);
   }
 
+  .hero__eyebrow,
+  .hero__subtitle {
+    font-size: 0.68rem;
+    letter-spacing: 0.08em;
+  }
+
   .hero__photo {
     width: min(260px, 55vw);
   }
@@ -984,6 +1062,14 @@ button:focus-visible {
     padding: 2rem 1.5rem;
   }
 
+  .projects__intro {
+    padding-bottom: 1.5rem;
+  }
+
+  .projects__heading {
+    max-width: none;
+  }
+
   .proj-card {
     padding: 2rem 0;
     opacity: 1;
@@ -1012,6 +1098,10 @@ button:focus-visible {
 
   .projects__cards {
     padding: 2rem 1rem;
+  }
+
+  .projects__meta-links {
+    gap: 0.75rem;
   }
 
   .exp-card {

--- a/index.html
+++ b/index.html
@@ -3,7 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="Rudraksh Bhandari - Portfolio Website" />
+    <meta
+      name="description"
+      content="Founder-engineer building consumer and public-interest software across mobile products, AI systems, and civic data."
+    />
     <meta name="keywords" content="portfolio, developer, software engineer, web developer" />
     <meta name="author" content="Rudraksh Bhandari" />
     <meta
@@ -27,7 +30,10 @@
     <!-- Open Graph Meta Tags -->
     <meta property="og:site_name" content="Rudraksh Bhandari" />
     <meta property="og:title" content="Rudraksh Bhandari - Portfolio" />
-    <meta property="og:description" content="Portfolio website showcasing my projects and skills" />
+    <meta
+      property="og:description"
+      content="Founder-engineer building consumer and public-interest software across mobile products, AI systems, and civic data."
+    />
     <meta property="og:image" content="https://rudrakshbhandari.com/img/Rudraksh-8.jpeg" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
@@ -37,7 +43,10 @@
     <!-- Twitter Card Meta Tags -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Rudraksh Bhandari - Portfolio" />
-    <meta name="twitter:description" content="Portfolio website showcasing my projects and skills" />
+    <meta
+      name="twitter:description"
+      content="Founder-engineer building consumer and public-interest software across mobile products, AI systems, and civic data."
+    />
     <meta name="twitter:image" content="https://rudrakshbhandari.com/img/Rudraksh-8.jpeg" />
 
     <title>Rudraksh Bhandari | Portfolio</title>
@@ -107,7 +116,7 @@
             <a href="#about" class="nav-link">About</a>
             <a href="#experience" class="nav-link">Experience</a>
             <a href="#projects" class="nav-link">Projects</a>
-            <a href="/health/" class="nav-link">Health</a>
+            <a href="/case-studies/" class="nav-link">Case Studies</a>
             <a href="#contact" class="nav-link">Contact</a>
             <a
               href="Rudraksh_Bhandari_Resume.pdf?v=1"
@@ -158,6 +167,7 @@
       <!-- ============================================ -->
       <section id="hero" class="scene scene--hero">
         <div class="hero__inner">
+          <p class="hero__eyebrow">Founder-led products, mobile systems, and public-interest software</p>
           <h1 class="hero__name" aria-label="Rudraksh Bhandari">
             <span class="hero__line hero__line--first">Rudraksh</span>
             <div class="hero__photo-wrap">
@@ -175,7 +185,7 @@
             </div>
             <span class="hero__line hero__line--last">Bhandari</span>
           </h1>
-          <p class="hero__subtitle">Software Engineer · 2x SDE Intern @ AWS · CS @ UCSD</p>
+          <p class="hero__subtitle">Co-founder @ NomNom · Building Outfitr · Former SDE Intern @ AWS</p>
         </div>
       </section>
 
@@ -203,27 +213,29 @@
             <h2 class="about__heading">About</h2>
 
             <p class="about__paragraph">
-              I'm Rudraksh Bhandari, a second-year Computer Science major at University of California San Diego and 2x
-              Software Development Engineer Intern at Amazon Web Services (Hyperplane team). I like building full-stack
-              applications to solve real-world problems.
+              I'm a founder-engineer and second-year Computer Science major at University of California San Diego. I
+              like building end-to-end products with clear real-world edges, especially consumer software, operational
+              systems, and public-interest data products.
             </p>
 
             <p class="about__paragraph">
-              At AWS Hyperplane, I developed frontend and backend tools that were adopted across the team, including a
-              CLI command generator that reduced on&#8209;call manual effort by ~75% and accelerated incident response
-              times.
+              Most recently, I spent two summers on the AWS Hyperplane team, where I shipped internal frontend and
+              backend tools adopted across the team, including a CLI command generator that reduced on&#8209;call manual
+              effort by ~75% and accelerated incident response.
             </p>
 
             <p class="about__paragraph">
-              I'm currently the Co&#8209;founder and Lead Developer of
-              <a href="https://nomnom.cc" target="_blank" rel="noopener noreferrer" class="text-link">NomNom</a>, a
-              UCSD&#8209;exclusive delivery startup with student courier and customer apps built in React Native and
-              Firebase, integrating Stripe payments, OTP verification, and live tracking.
+              My current operating work is
+              <a href="https://nomnom.cc" target="_blank" rel="noopener noreferrer" class="text-link">NomNom</a>, where
+              I lead product and engineering for a UCSD delivery startup, and Outfitr, where I'm building an AI-native
+              fashion discovery product across mobile, backend, and experimentation systems.
             </p>
 
             <p class="about__paragraph">
-              Previously, I founded and launched the ShareAllBooks mobile app, a UAE&#8209;based book&#8209;sharing
-              platform
+              Outside of current ventures, I like projects that have to stand up in the real world:
+              <a href="https://nyaaywatch.in" target="_blank" rel="noopener noreferrer" class="text-link">NyaayWatch</a>
+              turns Indian court-system snapshots into public evidence surfaces, and ShareAllBooks was a UAE
+              book-sharing app
               <a
                 href="https://www.khaleejtimes.com/uae/dubai-student-creates-app-for-free-exchange-of-books"
                 target="_blank"
@@ -231,18 +243,13 @@
                 class="text-link"
                 >featured in national press</a
               >
-              with 2,000+ downloads and 1,500+ book transactions.
+              that reached 2,000+ downloads and 1,500+ book transactions.
             </p>
 
             <p class="about__paragraph">
-              At Triton Software Engineering, I develop full&#8209;stack features for the David Brower Center platform—a
-              database for nonprofit organizations to visualize relationships between NPOs—using TypeScript, React,
-              Node.js, Prisma, and Postgres.
-            </p>
-
-            <p class="about__paragraph">
-              I also serve as Sophomore Representative at Triton Quantitative Trading, leading outreach and seminars on
-              risk management, game theory, and options strategies.
+              I also build full-stack features with Triton Software Engineering for the David Brower Center using
+              TypeScript, React, Node.js, Prisma, and Postgres, which keeps me sharp in team environments as well as
+              founder-led ones.
             </p>
 
             <div class="about__stats">
@@ -264,11 +271,35 @@
       <!-- ============================================ -->
       <section id="experience" class="scene scene--experience">
         <div class="experience__header">
-          <h2 class="experience__heading">Experience</h2>
+          <p class="section-kicker section-kicker--light">Current focus</p>
+          <h2 class="experience__heading">Experience & Current Ventures</h2>
+          <p class="section-intro section-intro--light">
+            Founder-led work first, followed by the teams where I've shipped production software and learned fast.
+          </p>
         </div>
         <div class="experience__track-wrapper">
           <div class="experience__track">
-            <!-- Card 1: AWS Hyperplane -->
+            <!-- Card 1: NomNom -->
+            <article class="exp-card">
+              <span class="exp-card__date">Sep 2025 – Present</span>
+              <h3 class="exp-card__company">NomNom</h3>
+              <h4 class="exp-card__role">Co-founder & Lead Developer</h4>
+              <p class="exp-card__location">San Diego, CA</p>
+              <ul class="exp-card__bullets">
+                <li>
+                  Built two React Native apps: Student app for ordering UCSD dining hall deliveries and Rider app for
+                  student couriers, using TypeScript, Firebase, and Stripe; implemented UCSD-only login and live
+                  tracking.
+                </li>
+                <li>
+                  Designed end-to-end order flow and Firestore transaction logic for OTP and drop-off delivery,
+                  preventing duplicate accepts.
+                </li>
+                <li>Integrated notifications, in-app chat, and live ETAs using Expo Location and React Native Maps.</li>
+              </ul>
+            </article>
+
+            <!-- Card 2: AWS Hyperplane -->
             <article class="exp-card">
               <span class="exp-card__date">Jun 2025 – Sep 2025</span>
               <h3 class="exp-card__company">Amazon Web Services</h3>
@@ -291,7 +322,7 @@
               </ul>
             </article>
 
-            <!-- Card 2: TSE David Brower Center -->
+            <!-- Card 3: TSE David Brower Center -->
             <article class="exp-card">
               <span class="exp-card__date">Nov 2025 – Present</span>
               <h3 class="exp-card__company">Triton Software Engineering</h3>
@@ -309,45 +340,7 @@
               </ul>
             </article>
 
-            <!-- Card 3: NomNom -->
-            <article class="exp-card">
-              <span class="exp-card__date">Sep 2025 – Present</span>
-              <h3 class="exp-card__company">NomNom</h3>
-              <h4 class="exp-card__role">Co-founder & Lead Developer</h4>
-              <p class="exp-card__location">San Diego, CA</p>
-              <ul class="exp-card__bullets">
-                <li>
-                  Built two React Native apps: Student app for ordering UCSD dining hall deliveries and Rider app for
-                  student couriers, using TypeScript, Firebase, and Stripe; implemented UCSD-only login and live
-                  tracking.
-                </li>
-                <li>
-                  Designed end-to-end order flow and Firestore transaction logic for OTP and drop-off delivery,
-                  preventing duplicate accepts.
-                </li>
-                <li>Integrated notifications, in-app chat, and live ETAs using Expo Location and React Native Maps.</li>
-              </ul>
-            </article>
-
-            <!-- Card 4: TSE Psyches of Color -->
-            <article class="exp-card">
-              <span class="exp-card__date">Nov 2024 – May 2025</span>
-              <h3 class="exp-card__company">Triton Software Engineering</h3>
-              <h4 class="exp-card__role">Software Developer · Psyches of Color</h4>
-              <p class="exp-card__location">San Diego, CA</p>
-              <ul class="exp-card__bullets">
-                <li>
-                  Developed full-stack features for Psyches of Color mobile app (MongoDB, Express.js, React Native,
-                  Node.js) to provide mental health resources for underserved communities.
-                </li>
-                <li>
-                  Collaborated within a 12-member cross-functional team (engineers, designers, PMs, EM) to implement
-                  frontend screens and backend APIs, improving app usability and streamlining data flow.
-                </li>
-              </ul>
-            </article>
-
-            <!-- Card 5: ShareAllBooks -->
+            <!-- Card 4: ShareAllBooks -->
             <article class="exp-card">
               <span class="exp-card__date">Aug 2023 – Sep 2024</span>
               <h3 class="exp-card__company">ShareAllBooks</h3>
@@ -374,6 +367,24 @@
                 </li>
               </ul>
             </article>
+
+            <!-- Card 5: TSE Psyches of Color -->
+            <article class="exp-card">
+              <span class="exp-card__date">Nov 2024 – May 2025</span>
+              <h3 class="exp-card__company">Triton Software Engineering</h3>
+              <h4 class="exp-card__role">Software Developer · Psyches of Color</h4>
+              <p class="exp-card__location">San Diego, CA</p>
+              <ul class="exp-card__bullets">
+                <li>
+                  Developed full-stack features for Psyches of Color mobile app (MongoDB, Express.js, React Native,
+                  Node.js) to provide mental health resources for underserved communities.
+                </li>
+                <li>
+                  Collaborated within a 12-member cross-functional team (engineers, designers, PMs, EM) to implement
+                  frontend screens and backend APIs, improving app usability and streamlining data flow.
+                </li>
+              </ul>
+            </article>
           </div>
         </div>
       </section>
@@ -386,7 +397,7 @@
           <!-- Project images (stacked, crossfaded) -->
           <div class="projects__images" aria-hidden="true">
             <img
-              src="img/nyaaywatch.svg?v=1"
+              src="img/nomnom.png?v=2"
               alt=""
               class="projects__img"
               data-project="0"
@@ -394,7 +405,7 @@
               decoding="async"
             />
             <img
-              src="img/nomnom.png?v=2"
+              src="img/outfitr-placeholder.svg?v=1"
               alt=""
               class="projects__img"
               data-project="1"
@@ -402,7 +413,7 @@
               decoding="async"
             />
             <img
-              src="img/outfitr-placeholder.svg?v=1"
+              src="img/nyaaywatch.svg?v=1"
               alt=""
               class="projects__img"
               data-project="2"
@@ -417,31 +428,80 @@
               loading="lazy"
               decoding="async"
             />
-            <img src="img/dbc.svg?v=1" alt="" class="projects__img" data-project="4" loading="lazy" decoding="async" />
-            <img
-              src="img/health-dashboard.png?v=1"
-              alt=""
-              class="projects__img"
-              data-project="5"
-              loading="lazy"
-              decoding="async"
-            />
             <img
               src="img/vibe-tracker.svg?v=1"
               alt=""
               class="projects__img"
-              data-project="6"
+              data-project="4"
               loading="lazy"
               decoding="async"
             />
-            <img src="img/poc.png?v=1" alt="" class="projects__img" data-project="7" loading="lazy" decoding="async" />
+            <img src="img/dbc.svg?v=1" alt="" class="projects__img" data-project="5" loading="lazy" decoding="async" />
+            <img src="img/poc.png?v=1" alt="" class="projects__img" data-project="6" loading="lazy" decoding="async" />
+            <img
+              src="img/health-dashboard.png?v=1"
+              alt=""
+              class="projects__img"
+              data-project="7"
+              loading="lazy"
+              decoding="async"
+            />
           </div>
 
           <!-- Project info cards -->
           <div class="projects__cards">
-            <!-- 1. NyaayWatch -->
+            <div class="projects__intro">
+              <p class="section-kicker">Selected work</p>
+              <h2 class="projects__heading">Current ventures plus the strongest proof underneath them</h2>
+              <p class="section-intro">
+                This section is intentionally top-loaded with the products I am actively building, then broader systems
+                and earlier proof of execution.
+              </p>
+              <div class="projects__meta-links">
+                <a href="/case-studies/" class="projects__meta-link">Case Studies</a>
+                <a href="/notes/" class="projects__meta-link">Notes</a>
+              </div>
+            </div>
+
+            <!-- 1. NomNom -->
             <article class="proj-card" data-project="0">
-              <h3 class="proj-card__title">NyaayWatch</h3>
+              <h3 class="proj-card__title">NomNom <span class="proj-card__badge">Current venture</span></h3>
+              <p class="proj-card__desc">
+                UCSD-exclusive delivery startup connecting students with dining hall couriers. UCSD-only authentication,
+                live ETAs, Stripe payments. Dual React Native apps (Student & Rider) with TypeScript, Firebase Firestore
+                transactions, real-time location tracking, OTP verification, and in-app chat.
+              </p>
+              <div class="proj-card__tech"><span>React Native</span><span>TypeScript</span><span>Firestore</span></div>
+              <a href="https://nomnom.cc" target="_blank" rel="noopener noreferrer" class="proj-card__link"
+                >Visit nomnom.cc →</a
+              >
+            </article>
+
+            <!-- 2. Outfitr -->
+            <article class="proj-card" data-project="1">
+              <h3 class="proj-card__title">Outfitr <span class="proj-card__badge">Current venture</span></h3>
+              <p class="proj-card__desc">
+                Built Outfitr, an AI-powered fashion discovery platform that aggregates multi-retailer catalogs and
+                generates complete outfit recommendations in a swipe-based mobile experience. Architected a TypeScript
+                monorepo spanning mobile, backend API, worker services, ingestion pipelines, and shared SDK/config
+                packages to support scalable product development. Designed backend systems for catalog normalization,
+                outfit composition, ranking, caching, and bundle generation to help users discover and purchase full
+                looks across merchants. Implemented AI virtual try-on infrastructure with async job orchestration,
+                provider abstraction, media storage, and privacy-conscious processing flows. Developed API and service
+                layers for user preferences, saved outfits, telemetry, and experimentation to support personalization
+                and product iteration.
+              </p>
+              <div class="proj-card__tech">
+                <span>TypeScript</span><span>AI</span><span>Mobile</span><span>Fashion</span>
+              </div>
+              <a href="https://outfitr.net/" target="_blank" rel="noopener noreferrer" class="proj-card__link"
+                >Visit outfitr.net →</a
+              >
+            </article>
+
+            <!-- 3. NyaayWatch -->
+            <article class="proj-card" data-project="2">
+              <h3 class="proj-card__title">NyaayWatch <span class="proj-card__badge">Selected project</span></h3>
               <p class="proj-card__desc">
                 Built an evidence-first platform for making Indian court backlog and district-level judicial performance
                 legible to the public. A public-interest judicial observability platform that turns published Indian
@@ -468,42 +528,6 @@
               >
             </article>
 
-            <!-- 2. NomNom -->
-            <article class="proj-card" data-project="1">
-              <h3 class="proj-card__title">NomNom</h3>
-              <p class="proj-card__desc">
-                UCSD-exclusive delivery startup connecting students with dining hall couriers. UCSD-only authentication,
-                live ETAs, Stripe payments. Dual React Native apps (Student & Rider) with TypeScript, Firebase Firestore
-                transactions, real-time location tracking, OTP verification, and in-app chat.
-              </p>
-              <div class="proj-card__tech"><span>React Native</span><span>TypeScript</span><span>Firestore</span></div>
-              <a href="https://nomnom.cc" target="_blank" rel="noopener noreferrer" class="proj-card__link"
-                >Visit nomnom.cc →</a
-              >
-            </article>
-
-            <!-- 3. Outfitr -->
-            <article class="proj-card" data-project="2">
-              <h3 class="proj-card__title">Outfitr <span class="proj-card__badge">Launching soon</span></h3>
-              <p class="proj-card__desc">
-                Built Outfitr, an AI-powered fashion discovery platform that aggregates multi-retailer catalogs and
-                generates complete outfit recommendations in a swipe-based mobile experience. Architected a TypeScript
-                monorepo spanning mobile, backend API, worker services, ingestion pipelines, and shared SDK/config
-                packages to support scalable product development. Designed backend systems for catalog normalization,
-                outfit composition, ranking, caching, and bundle generation to help users discover and purchase full
-                looks across merchants. Implemented AI virtual try-on infrastructure with async job orchestration,
-                provider abstraction, media storage, and privacy-conscious processing flows. Developed API and service
-                layers for user preferences, saved outfits, telemetry, and experimentation to support personalization
-                and product iteration.
-              </p>
-              <div class="proj-card__tech">
-                <span>TypeScript</span><span>AI</span><span>Mobile</span><span>Fashion</span>
-              </div>
-              <a href="https://outfitr.net/" target="_blank" rel="noopener noreferrer" class="proj-card__link"
-                >Visit outfitr.net →</a
-              >
-            </article>
-
             <!-- 4. ShareAllBooks -->
             <article class="proj-card" data-project="3">
               <h3 class="proj-card__title">ShareAllBooks</h3>
@@ -524,8 +548,28 @@
               >
             </article>
 
-            <!-- 5. David Brower Center -->
+            <!-- 5. Vibe Tracker -->
             <article class="proj-card" data-project="4">
+              <h3 class="proj-card__title">Vibe Tracker</h3>
+              <p class="proj-card__desc">
+                Built a Next.js and TypeScript analytics platform for GitHub productivity tracking. Aggregates GitHub
+                commit activity across repos, branches, and pull requests using deduplicated SHA-based tracking, with
+                GitHub OAuth/App integration, Prisma/PostgreSQL data modeling, and real-time productivity dashboards.
+              </p>
+              <div class="proj-card__tech">
+                <span>Next.js</span><span>TypeScript</span><span>Prisma</span><span>PostgreSQL</span>
+              </div>
+              <a
+                href="https://vibe-tracker-max.vercel.app/"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="proj-card__link"
+                >Visit live →</a
+              >
+            </article>
+
+            <!-- 6. David Brower Center -->
+            <article class="proj-card" data-project="5">
               <h3 class="proj-card__title">David Brower Center</h3>
               <p class="proj-card__desc">
                 Database platform for nonprofit organizations to visualize relationships between NPOs. Full-stack
@@ -545,43 +589,8 @@
               >
             </article>
 
-            <!-- 6. Health Dashboard -->
-            <article class="proj-card" data-project="5">
-              <h3 class="proj-card__title">Health Metrics Dashboard</h3>
-              <p class="proj-card__desc">
-                Personal health analytics dashboard with automated Oura Ring data pipeline. Built a live dashboard that
-                ingests and visualizes daily sleep, readiness, HRV, and activity metrics from the Oura API. Automated
-                data refresh via GitHub Actions with secure token handling. Features trend charts, historical
-                comparisons, and real-time metric cards with status indicators.
-              </p>
-              <div class="proj-card__tech">
-                <span>JavaScript</span><span>Oura API</span><span>GitHub Actions</span><span>Chart.js</span>
-              </div>
-              <a href="/health/" class="proj-card__link">View dashboard →</a>
-            </article>
-
-            <!-- 7. Vibe Tracker -->
+            <!-- 7. Psyches of Color -->
             <article class="proj-card" data-project="6">
-              <h3 class="proj-card__title">Vibe Tracker</h3>
-              <p class="proj-card__desc">
-                Built a Next.js and TypeScript analytics platform for GitHub productivity tracking. Aggregates GitHub
-                commit activity across repos, branches, and pull requests using deduplicated SHA-based tracking, with
-                GitHub OAuth/App integration, Prisma/PostgreSQL data modeling, and real-time productivity dashboards.
-              </p>
-              <div class="proj-card__tech">
-                <span>Next.js</span><span>TypeScript</span><span>Prisma</span><span>PostgreSQL</span>
-              </div>
-              <a
-                href="https://vibe-tracker-max.vercel.app/"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="proj-card__link"
-                >Visit live →</a
-              >
-            </article>
-
-            <!-- 8. Psyches of Color -->
-            <article class="proj-card" data-project="7">
               <h3 class="proj-card__title">Psyches of Color</h3>
               <p class="proj-card__desc">
                 Psyches of Color develops a mental health app serving underserved communities. Full-stack development
@@ -596,6 +605,21 @@
                 class="proj-card__link"
                 >View on GitHub →</a
               >
+            </article>
+
+            <!-- 8. Health Dashboard -->
+            <article class="proj-card" data-project="7">
+              <h3 class="proj-card__title">Health Metrics Dashboard</h3>
+              <p class="proj-card__desc">
+                Personal health analytics dashboard with automated Oura Ring data pipeline. Built a personal dashboard
+                that ingests and visualizes daily sleep, readiness, HRV, and activity metrics from the Oura API.
+                Automated data refresh via GitHub Actions with secure token handling. Features trend charts, historical
+                comparisons, and metric cards with status indicators.
+              </p>
+              <div class="proj-card__tech">
+                <span>JavaScript</span><span>Oura API</span><span>GitHub Actions</span><span>Chart.js</span>
+              </div>
+              <a href="/health/" class="proj-card__link">View dashboard →</a>
             </article>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- reframe the homepage hero and About copy around a clearer founder-engineer thesis
- reorder and relabel homepage sections so current ventures read first and proof projects are easier to parse
- promote case studies in the nav and project section while demoting lower-signal side material from the front door

## Validation
- npm run ci:check