### PR TITLE
Fix clipped hero reviewer text

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -338,17 +338,6 @@ button:focus-visible {
   overflow: hidden;
 }
 
-.hero__eyebrow {
-  font-family: var(--font-display);
-  font-size: 0.75rem;
-  font-weight: 700;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: var(--color-accent);
-  margin-bottom: 1.5rem;
-  text-align: center;
-}
-
 .hero__name {
   display: flex;
   flex-direction: column;
@@ -415,13 +404,30 @@ button:focus-visible {
   font-size: clamp(0.65rem, 1vw, 0.8rem);
   font-weight: 600;
   color: var(--color-text);
-  opacity: 0.45;
   margin-top: 2rem;
   position: relative;
   z-index: 2;
   letter-spacing: 0.12em;
   text-transform: uppercase;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  text-align: center;
   will-change: opacity;
+}
+
+.hero__subtitle-line {
+  display: block;
+}
+
+.hero__subtitle-line--lede {
+  color: var(--color-accent);
+  opacity: 0.85;
+}
+
+.hero__subtitle-line:not(.hero__subtitle-line--lede) {
+  opacity: 0.45;
 }
 
 /* =============================================
@@ -994,7 +1000,6 @@ button:focus-visible {
     font-size: clamp(2.8rem, 11vw, 5rem);
   }
 
-  .hero__eyebrow,
   .hero__subtitle {
     font-size: 0.68rem;
     letter-spacing: 0.08em;

--- a/index.html
+++ b/index.html
@@ -167,7 +167,6 @@
       <!-- ============================================ -->
       <section id="hero" class="scene scene--hero">
         <div class="hero__inner">
-          <p class="hero__eyebrow">Founder-led products, mobile systems, and public-interest software</p>
           <h1 class="hero__name" aria-label="Rudraksh Bhandari">
             <span class="hero__line hero__line--first">Rudraksh</span>
             <div class="hero__photo-wrap">
@@ -185,7 +184,12 @@
             </div>
             <span class="hero__line hero__line--last">Bhandari</span>
           </h1>
-          <p class="hero__subtitle">Co-founder @ NomNom · Building Outfitr · Former SDE Intern @ AWS</p>
+          <p class="hero__subtitle">
+            <span class="hero__subtitle-line hero__subtitle-line--lede">
+              Founder-led products, mobile systems, and public-interest software
+            </span>
+            <span class="hero__subtitle-line">Co-founder @ NomNom · Building Outfitr · Former SDE Intern @ AWS</span>
+          </p>
         </div>
       </section>
 

--- a/js/animations.js
+++ b/js/animations.js
@@ -97,14 +97,14 @@ function initHeroScene() {
 
     gsap.set([firstLine, lastLine], { opacity: 1 });
     gsap.set(photoWrap, { opacity: 1, scale: 1 });
-    gsap.set(subtitle, { opacity: 0.45 });
+    gsap.set(subtitle, { opacity: 1 });
   }
 
   function syncHeroToProgress(progress) {
     gsap.set(firstLine, { opacity: 1, y: overlap - progress * spread });
     gsap.set(lastLine, { opacity: 1, y: -overlap + progress * spread });
     gsap.set(photoWrap, { opacity: 1, scale: 1 + progress * 0.015 });
-    gsap.set(subtitle, { opacity: 0.45 });
+    gsap.set(subtitle, { opacity: 1 });
   }
 
   var entrance = gsap.timeline({
@@ -117,7 +117,7 @@ function initHeroScene() {
   entrance.to(firstLine, { opacity: 1, y: overlap, duration: 0.9, ease: 'power3.out' });
   entrance.to(photoWrap, { opacity: 1, scale: 1, duration: 1, ease: 'power3.out' }, 0.15);
   entrance.to(lastLine, { opacity: 1, y: -overlap, duration: 0.9, ease: 'power3.out' }, 0.25);
-  entrance.to(subtitle, { opacity: 0.45, duration: 0.8, ease: 'power2.out' }, 0.7);
+  entrance.to(subtitle, { opacity: 1, duration: 0.8, ease: 'power2.out' }, 0.7);
 
   /* --- Scroll: name lines breathe outward from tight overlap --- */
   ScrollTrigger.create({


### PR DESCRIPTION
## Summary
- remove the extra top hero line that was pushing content under the fixed navbar
- move the reviewer-facing framing into the existing subtitle block below the hero image
- keep the reviewer positioning copy while restoring a clean first viewport on desktop and mobile

## Validation
- npm run ci:check
- verified locally in desktop and mobile viewports before pushing