### PR TITLE
Tighten homepage reviewer-facing copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,7 +116,6 @@
             <a href="#about" class="nav-link">About</a>
             <a href="#experience" class="nav-link">Experience</a>
             <a href="#projects" class="nav-link">Projects</a>
-            <a href="/case-studies/" class="nav-link">Case Studies</a>
             <a href="#contact" class="nav-link">Contact</a>
             <a
               href="Rudraksh_Bhandari_Resume.pdf?v=1"
@@ -188,7 +187,7 @@
             <span class="hero__subtitle-line hero__subtitle-line--lede">
               Founder-led products, mobile systems, and public-interest software
             </span>
-            <span class="hero__subtitle-line">Co-founder @ NomNom · Building Outfitr · Former SDE Intern @ AWS</span>
+            <span class="hero__subtitle-line">Co-founder @ NomNom · Building Outfitr · 2x SDE Intern @ AWS</span>
           </p>
         </div>
       </section>
@@ -457,14 +456,6 @@
             <div class="projects__intro">
               <p class="section-kicker">Selected work</p>
               <h2 class="projects__heading">Current ventures plus the strongest proof underneath them</h2>
-              <p class="section-intro">
-                This section is intentionally top-loaded with the products I am actively building, then broader systems
-                and earlier proof of execution.
-              </p>
-              <div class="projects__meta-links">
-                <a href="/case-studies/" class="projects__meta-link">Case Studies</a>
-                <a href="/notes/" class="projects__meta-link">Notes</a>
-              </div>
             </div>
 
             <!-- 1. NomNom -->
@@ -505,7 +496,7 @@
 
             <!-- 3. NyaayWatch -->
             <article class="proj-card" data-project="2">
-              <h3 class="proj-card__title">NyaayWatch <span class="proj-card__badge">Selected project</span></h3>
+              <h3 class="proj-card__title">NyaayWatch</h3>
               <p class="proj-card__desc">
                 Built an evidence-first platform for making Indian court backlog and district-level judicial performance
                 legible to the public. A public-interest judicial observability platform that turns published Indian


### PR DESCRIPTION
## Summary
- change the AWS hero line to use the requested 2x SDE Intern framing
- remove the explanatory paragraph under the projects intro
- remove unfinished Case Studies and Notes links from the homepage and nav
- drop the awkward NyaayWatch selected-project badge

## Validation
- npm run ci:check