### PR TITLE
Link research labs and refine about photo placement

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -451,11 +451,13 @@ button:focus-visible {
 
 .about__photo-col {
   position: relative;
+  display: flex;
+  justify-content: center;
 }
 
 .about__photo-sticky {
   position: sticky;
-  top: 100px;
+  top: max(100px, calc(50vh - 280px));
 }
 
 .about__photo {
@@ -469,6 +471,7 @@ button:focus-visible {
     0 20px 50px rgba(0, 0, 0, 0.1),
     0 5px 15px rgba(0, 0, 0, 0.05);
   transition: filter 0.8s ease;
+  margin: 0 auto;
 }
 
 .about__text-col {

--- a/index.html
+++ b/index.html
@@ -220,8 +220,14 @@
 
             <p class="about__paragraph">
               I'm a second-year Computer Science major and ML researcher at University of California San Diego, where
-              I'm working with the Alternative Computing Technologies Lab and the Statistical Visual Computing Lab
-              (SVCL). I like building end-to-end products with clear real-world edges, especially consumer software,
+              I'm working with the
+              <a href="http://act-lab.org/" target="_blank" rel="noopener noreferrer" class="text-link"
+                >Alternative Computing Technologies Lab</a
+              >
+              and the
+              <a href="http://www.svcl.ucsd.edu/" target="_blank" rel="noopener noreferrer" class="text-link"
+                >Statistical Visual Computing Lab (SVCL)</a
+              >. I like building end-to-end products with clear real-world edges, especially consumer software,
               operational systems, and public-interest data products.
             </p>
 


### PR DESCRIPTION
## Summary
- add text links for ACT Lab and SVCL in the About intro
- center the desktop About photo more intentionally within its column
- keep the mobile About layout unchanged

## Validation
- npm run ci:check