### PR TITLE
Center about photo and update intro copy

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -446,18 +446,21 @@ button:focus-visible {
   display: grid;
   grid-template-columns: 0.4fr 0.6fr;
   gap: 4rem;
-  align-items: start;
+  align-items: center;
 }
 
 .about__photo-col {
   position: relative;
   display: flex;
+  align-items: center;
   justify-content: center;
 }
 
 .about__photo-sticky {
   position: sticky;
-  top: max(100px, calc(50vh - 280px));
+  top: clamp(100px, calc(50vh - 280px), 240px);
+  width: 100%;
+  max-width: 420px;
 }
 
 .about__photo {

--- a/index.html
+++ b/index.html
@@ -232,9 +232,9 @@
             </p>
 
             <p class="about__paragraph">
-              Most recently, I spent two summers on the AWS Hyperplane team, where I shipped internal frontend and
-              backend tools adopted across the team, including a CLI command generator that reduced on&#8209;call manual
-              effort by ~75% and accelerated incident response.
+              Last summer, I interned on the AWS Hyperplane team, and I'll be returning this coming summer. I shipped
+              internal frontend and backend tools adopted across the team, including a CLI command generator that
+              reduced on&#8209;call manual effort by ~75% and accelerated incident response.
             </p>
 
             <p class="about__paragraph">


### PR DESCRIPTION
## Summary
- vertically center the desktop About photo within its column
- add text links for ACT Lab and SVCL in the About intro
- correct the AWS sentence to refer to last summer and the upcoming return internship

## Validation
- npm run ci:check