### PR TITLE
fix: link Outfitr in About intro

### DIFF
--- a/index.html
+++ b/index.html
@@ -240,8 +240,9 @@
             <p class="about__paragraph">
               I'm currently building
               <a href="https://nomnom.cc" target="_blank" rel="noopener noreferrer" class="text-link">NomNom</a>, a UCSD
-              delivery product, and Outfitr, an AI-native fashion discovery product across mobile, backend, and
-              experimentation systems.
+              delivery product, and
+              <a href="https://outfitr.net/" target="_blank" rel="noopener noreferrer" class="text-link">Outfitr</a>, an
+              AI-native fashion discovery product across mobile, backend, and experimentation systems.
             </p>
 
             <p class="about__paragraph">


### PR DESCRIPTION
## Summary
- add the missing Outfitr hyperlink in the About paragraph
- point the link to https://outfitr.net/ with the existing external-link styling

## Testing
- npm run ci:check