### PR TITLE
style: restore about photo desktop size

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -444,25 +444,27 @@ button:focus-visible {
   margin: 0 auto;
   padding: 0 2rem;
   display: grid;
-  grid-template-columns: 0.4fr 0.6fr;
-  gap: 4rem;
+  grid-template-columns: minmax(380px, 480px) minmax(0, 1fr);
+  gap: 3rem;
   align-items: start;
 }
 
 .about__photo-col {
   position: relative;
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
 }
 
 .about__photo-sticky {
   position: sticky;
   top: max(100px, calc(50vh - 280px));
+  width: 100%;
+  max-width: 480px;
 }
 
 .about__photo {
   width: 100%;
-  max-width: 420px;
+  max-width: none;
   aspect-ratio: 3 / 4;
   object-fit: cover;
   object-position: 55% center;

--- a/css/styles.css
+++ b/css/styles.css
@@ -446,18 +446,19 @@ button:focus-visible {
   display: grid;
   grid-template-columns: minmax(380px, 480px) minmax(0, 1fr);
   gap: 3rem;
-  align-items: start;
+  align-items: center;
 }
 
 .about__photo-col {
   position: relative;
   display: flex;
+  align-items: center;
   justify-content: flex-start;
 }
 
 .about__photo-sticky {
   position: sticky;
-  top: max(100px, calc(50vh - 280px));
+  top: clamp(100px, calc(50vh - 320px), 220px);
   width: 100%;
   max-width: 480px;
 }
@@ -477,7 +478,7 @@ button:focus-visible {
 }
 
 .about__text-col {
-  padding-top: 2rem;
+  padding-top: 0;
 }
 
 .about__heading {


### PR DESCRIPTION
## Summary
- restore the desktop About photo to a larger width instead of keeping it capped inside the narrower previous column layout
- make the photo column match the image width so it no longer reads undersized on wide screens

## Validation
- npm run format:check
