### PR TITLE
fix: bust cached production stylesheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
     </script>
 
     <!-- Custom CSS -->
-    <link rel="stylesheet" href="css/styles.css" />
+    <link rel="stylesheet" href="css/styles.css?v=2" />
 
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">


### PR DESCRIPTION
## Summary
- version the main stylesheet URL so browsers stop serving stale cached CSS after production merges
- ensure production picks up the larger About photo layout immediately instead of waiting for the old `styles.css` cache to expire

## Validation
- npm run format:check
- local preview requested `css/styles.css?v=2`
