### PR TITLE
style(hero): split portrait to frame credential line

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -383,12 +383,14 @@ button:focus-visible {
 .hero__photo-wrap {
   --hero-photo-width: min(420px, 50vw);
   --hero-photo-height: calc(var(--hero-photo-width) * 4 / 3);
-  --hero-gap: clamp(4rem, 5vw, 5.25rem);
-  --hero-split-offset: 0px;
+  --hero-gap-max: clamp(4rem, 5vw, 5.25rem);
+  --hero-gap-open: 0px;
+  --hero-band-opacity: 0;
+  --hero-split-point: 0.58;
   position: relative;
   z-index: 1;
   width: var(--hero-photo-width);
-  height: calc(var(--hero-photo-height) + var(--hero-gap));
+  height: calc(var(--hero-photo-height) + var(--hero-gap-max));
   margin: -1.1em 0 -0.8em;
   will-change: transform, opacity;
 }
@@ -397,7 +399,7 @@ button:focus-visible {
   position: absolute;
   left: 0;
   width: 100%;
-  height: calc((var(--hero-photo-height) - var(--hero-gap)) / 2);
+  height: calc(var(--hero-photo-height) * var(--hero-split-point));
   overflow: hidden;
   box-shadow:
     0 30px 80px rgba(0, 0, 0, 0.15),
@@ -408,13 +410,14 @@ button:focus-visible {
 .hero__photo-half--top {
   top: 0;
   border-radius: 14px 14px 0 0;
-  transform: translateY(calc(var(--hero-split-offset) * -1));
+  transform: translateY(calc((var(--hero-gap-max) - var(--hero-gap-open)) / 2));
 }
 
 .hero__photo-half--bottom {
   bottom: 0;
+  height: calc(var(--hero-photo-height) * (1 - var(--hero-split-point)));
   border-radius: 0 0 14px 14px;
-  transform: translateY(var(--hero-split-offset));
+  transform: translateY(calc((var(--hero-gap-open) - var(--hero-gap-max)) / 2));
 }
 
 .hero__photo-fragment {
@@ -439,7 +442,7 @@ button:focus-visible {
   position: absolute;
   inset-inline: clamp(0.8rem, 3vw, 1.25rem);
   top: 50%;
-  transform: translateY(-50%);
+  transform: translateY(-50%) scale(calc(0.96 + (var(--hero-band-opacity) * 0.04)));
   min-height: clamp(3.2rem, 5vw, 4rem);
   display: flex;
   align-items: center;
@@ -452,6 +455,8 @@ button:focus-visible {
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
   z-index: 3;
+  opacity: var(--hero-band-opacity);
+  pointer-events: none;
 }
 
 .hero__headline-band-text {
@@ -491,6 +496,10 @@ button:focus-visible {
 .hero__subtitle-line--lede {
   color: var(--color-accent);
   opacity: 0.85;
+}
+
+.hero__subtitle-line--credentials {
+  opacity: 0.45;
 }
 
 /* =============================================
@@ -1071,7 +1080,7 @@ button:focus-visible {
 
   .hero__photo-wrap {
     --hero-photo-width: min(270px, 62vw);
-    --hero-gap: clamp(3.4rem, 10vw, 4.25rem);
+    --hero-gap-max: clamp(3.4rem, 10vw, 4.25rem);
     margin: -0.7em 0 -0.45em;
   }
 
@@ -1193,7 +1202,7 @@ button:focus-visible {
 
   .hero__photo-wrap {
     --hero-photo-width: min(224px, 62vw);
-    --hero-gap: 3.25rem;
+    --hero-gap-max: 3.25rem;
   }
 
   .hero__headline-band-text {
@@ -1245,6 +1254,19 @@ button:focus-visible {
   .hero__inner {
     position: relative;
   }
+}
+
+.hero-static .hero__photo-wrap {
+  height: var(--hero-photo-height);
+}
+
+.hero-static .hero__photo-half--top,
+.hero-static .hero__photo-half--bottom {
+  transform: none;
+}
+
+.hero-static .hero__headline-band {
+  display: none;
 }
 
 /* =============================================

--- a/css/styles.css
+++ b/css/styles.css
@@ -381,22 +381,89 @@ button:focus-visible {
 }
 
 .hero__photo-wrap {
+  --hero-photo-width: min(420px, 50vw);
+  --hero-photo-height: calc(var(--hero-photo-width) * 4 / 3);
+  --hero-gap: clamp(4rem, 5vw, 5.25rem);
+  --hero-split-offset: 0px;
   position: relative;
   z-index: 1;
-  margin: -0.6em 0;
+  width: var(--hero-photo-width);
+  height: calc(var(--hero-photo-height) + var(--hero-gap));
+  margin: -1.1em 0 -0.8em;
   will-change: transform, opacity;
 }
 
-.hero__photo {
-  width: min(420px, 50vw);
-  height: auto;
-  aspect-ratio: 3 / 4;
-  object-fit: cover;
-  object-position: 50% 25%;
-  border-radius: 14px;
+.hero__photo-half {
+  position: absolute;
+  left: 0;
+  width: 100%;
+  height: calc((var(--hero-photo-height) - var(--hero-gap)) / 2);
+  overflow: hidden;
   box-shadow:
     0 30px 80px rgba(0, 0, 0, 0.15),
     0 10px 25px rgba(0, 0, 0, 0.08);
+  will-change: transform;
+}
+
+.hero__photo-half--top {
+  top: 0;
+  border-radius: 14px 14px 0 0;
+  transform: translateY(calc(var(--hero-split-offset) * -1));
+}
+
+.hero__photo-half--bottom {
+  bottom: 0;
+  border-radius: 0 0 14px 14px;
+  transform: translateY(var(--hero-split-offset));
+}
+
+.hero__photo-fragment {
+  position: absolute;
+  left: 0;
+  width: 100%;
+  height: var(--hero-photo-height);
+  object-fit: cover;
+  object-position: 50% 25%;
+  display: block;
+}
+
+.hero__photo-fragment--top {
+  top: 0;
+}
+
+.hero__photo-fragment--bottom {
+  bottom: 0;
+}
+
+.hero__headline-band {
+  position: absolute;
+  inset-inline: clamp(0.8rem, 3vw, 1.25rem);
+  top: 50%;
+  transform: translateY(-50%);
+  min-height: clamp(3.2rem, 5vw, 4rem);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.7rem 1rem;
+  background: rgba(245, 240, 235, 0.88);
+  border-top: 1px solid rgba(28, 26, 24, 0.08);
+  border-bottom: 1px solid rgba(28, 26, 24, 0.08);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.08);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  z-index: 3;
+}
+
+.hero__headline-band-text {
+  font-family: var(--font-display);
+  font-size: clamp(0.72rem, 1vw, 0.9rem);
+  font-weight: 700;
+  line-height: 1.4;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  text-align: center;
+  text-wrap: balance;
+  color: rgba(28, 26, 24, 0.82);
 }
 
 .hero__subtitle {
@@ -404,7 +471,7 @@ button:focus-visible {
   font-size: clamp(0.65rem, 1vw, 0.8rem);
   font-weight: 600;
   color: var(--color-text);
-  margin-top: 2rem;
+  margin-top: 1.4rem;
   position: relative;
   z-index: 2;
   letter-spacing: 0.12em;
@@ -424,10 +491,6 @@ button:focus-visible {
 .hero__subtitle-line--lede {
   color: var(--color-accent);
   opacity: 0.85;
-}
-
-.hero__subtitle-line:not(.hero__subtitle-line--lede) {
-  opacity: 0.45;
 }
 
 /* =============================================
@@ -1006,17 +1069,26 @@ button:focus-visible {
     font-size: clamp(2.8rem, 11vw, 5rem);
   }
 
+  .hero__photo-wrap {
+    --hero-photo-width: min(270px, 62vw);
+    --hero-gap: clamp(3.4rem, 10vw, 4.25rem);
+    margin: -0.7em 0 -0.45em;
+  }
+
+  .hero__headline-band {
+    inset-inline: 0.5rem;
+    padding: 0.65rem 0.75rem;
+  }
+
+  .hero__headline-band-text {
+    font-size: 0.62rem;
+    letter-spacing: 0.09em;
+  }
+
   .hero__subtitle {
     font-size: 0.68rem;
     letter-spacing: 0.08em;
-  }
-
-  .hero__photo {
-    width: min(260px, 55vw);
-  }
-
-  .hero__photo-wrap {
-    margin: -0.4em 0;
+    margin-top: 1.15rem;
   }
 
   /* About */
@@ -1119,12 +1191,13 @@ button:focus-visible {
     padding: 1.75rem;
   }
 
-  .hero__photo {
-    width: min(220px, 55vw);
+  .hero__photo-wrap {
+    --hero-photo-width: min(224px, 62vw);
+    --hero-gap: 3.25rem;
   }
 
-  .hero__photo-wrap {
-    margin: -0.3em 0;
+  .hero__headline-band-text {
+    font-size: 0.58rem;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -169,27 +169,43 @@
         <div class="hero__inner">
           <h1 class="hero__name" aria-label="Rudraksh Bhandari">
             <span class="hero__line hero__line--first">Rudraksh</span>
-            <div class="hero__photo-wrap">
-              <img
-                src="img/Rudraksh-8-600.jpg"
-                srcset="img/Rudraksh-8-600.jpg 600w, img/Rudraksh-8-1200.jpg 1200w"
-                sizes="(max-width: 768px) 260px, 420px"
-                alt="Rudraksh Bhandari"
-                class="hero__photo"
-                width="420"
-                height="560"
-                fetchpriority="high"
-                decoding="async"
-              />
+            <div class="hero__photo-wrap" role="img" aria-label="Rudraksh Bhandari">
+              <div class="hero__photo-half hero__photo-half--top" aria-hidden="true">
+                <img
+                  src="img/Rudraksh-8-600.jpg"
+                  srcset="img/Rudraksh-8-600.jpg 600w, img/Rudraksh-8-1200.jpg 1200w"
+                  sizes="(max-width: 768px) 260px, 420px"
+                  alt=""
+                  class="hero__photo-fragment hero__photo-fragment--top"
+                  width="420"
+                  height="560"
+                  fetchpriority="high"
+                  decoding="async"
+                />
+              </div>
+              <div class="hero__headline-band">
+                <span class="hero__headline-band-text"
+                  >ML Researcher @ UCSD · 2x SDE Intern @ AWS · Building NomNom and Outfitr</span
+                >
+              </div>
+              <div class="hero__photo-half hero__photo-half--bottom" aria-hidden="true">
+                <img
+                  src="img/Rudraksh-8-600.jpg"
+                  srcset="img/Rudraksh-8-600.jpg 600w, img/Rudraksh-8-1200.jpg 1200w"
+                  sizes="(max-width: 768px) 260px, 420px"
+                  alt=""
+                  class="hero__photo-fragment hero__photo-fragment--bottom"
+                  width="420"
+                  height="560"
+                  decoding="async"
+                />
+              </div>
             </div>
             <span class="hero__line hero__line--last">Bhandari</span>
           </h1>
           <p class="hero__subtitle">
             <span class="hero__subtitle-line hero__subtitle-line--lede"
               >Machine learning, mobile systems, and public-interest software</span
-            >
-            <span class="hero__subtitle-line"
-              >ML Researcher @ UCSD · 2x SDE Intern @ AWS · Building NomNom and Outfitr</span
             >
           </p>
         </div>

--- a/js/animations.js
+++ b/js/animations.js
@@ -51,6 +51,7 @@ function initStaticFallback() {
   if (heroPhotoWrap) {
     heroPhotoWrap.style.opacity = '1';
     heroPhotoWrap.style.transform = 'none';
+    heroPhotoWrap.style.setProperty('--hero-split-offset', '0px');
   }
   if (heroSubtitle) {
     heroSubtitle.style.opacity = '1';
@@ -85,8 +86,9 @@ function initHeroScene() {
   if (!heroSection || !heroInner || !firstLine || !lastLine || !photoWrap) return;
 
   /* --- Entrance: elements land in a tight, overlapping position --- */
-  var overlap = 50;
-  var spread = overlap + 20;
+  var overlap = 42;
+  var spread = overlap + 26;
+  var splitDistance = 42;
   var entranceSettled = false;
 
   function finishEntrance() {
@@ -96,14 +98,18 @@ function initHeroScene() {
     entrance.kill();
 
     gsap.set([firstLine, lastLine], { opacity: 1 });
-    gsap.set(photoWrap, { opacity: 1, scale: 1 });
+    gsap.set(photoWrap, { opacity: 1, scale: 1, '--hero-split-offset': '0px' });
     gsap.set(subtitle, { opacity: 1 });
   }
 
   function syncHeroToProgress(progress) {
     gsap.set(firstLine, { opacity: 1, y: overlap - progress * spread });
     gsap.set(lastLine, { opacity: 1, y: -overlap + progress * spread });
-    gsap.set(photoWrap, { opacity: 1, scale: 1 + progress * 0.015 });
+    gsap.set(photoWrap, {
+      opacity: 1,
+      scale: 1 + progress * 0.012,
+      '--hero-split-offset': progress * splitDistance + 'px',
+    });
     gsap.set(subtitle, { opacity: 1 });
   }
 

--- a/js/animations.js
+++ b/js/animations.js
@@ -39,10 +39,14 @@ document.addEventListener('DOMContentLoaded', function () {
 function initStaticFallback() {
   var heroLines = document.querySelectorAll('.hero__line');
   var heroPhotoWrap = document.querySelector('.hero__photo-wrap');
+  var heroHeadlineBand = document.querySelector('.hero__headline-band');
+  var heroHeadlineBandText = document.querySelector('.hero__headline-band-text');
   var heroSubtitle = document.querySelector('.hero__subtitle');
   var paragraphs = document.querySelectorAll('.about__paragraph');
   var projCards = document.querySelectorAll('.proj-card');
   var projImages = document.querySelectorAll('.projects__img');
+
+  document.body.classList.add('hero-static');
 
   heroLines.forEach(function (line) {
     line.style.opacity = '1';
@@ -51,10 +55,22 @@ function initStaticFallback() {
   if (heroPhotoWrap) {
     heroPhotoWrap.style.opacity = '1';
     heroPhotoWrap.style.transform = 'none';
-    heroPhotoWrap.style.setProperty('--hero-split-offset', '0px');
+    heroPhotoWrap.style.setProperty('--hero-gap-open', '0px');
+    heroPhotoWrap.style.setProperty('--hero-band-opacity', '0');
   }
   if (heroSubtitle) {
     heroSubtitle.style.opacity = '1';
+  }
+  if (
+    heroHeadlineBand &&
+    heroHeadlineBandText &&
+    heroSubtitle &&
+    !heroSubtitle.querySelector('.hero__subtitle-line--credentials')
+  ) {
+    var credentialsLine = document.createElement('span');
+    credentialsLine.className = 'hero__subtitle-line hero__subtitle-line--credentials';
+    credentialsLine.textContent = heroHeadlineBandText.textContent;
+    heroSubtitle.appendChild(credentialsLine);
   }
 
   paragraphs.forEach(function (p) {
@@ -88,7 +104,7 @@ function initHeroScene() {
   /* --- Entrance: elements land in a tight, overlapping position --- */
   var overlap = 42;
   var spread = overlap + 26;
-  var splitDistance = 42;
+  var splitDistance = 84;
   var entranceSettled = false;
 
   function finishEntrance() {
@@ -98,17 +114,21 @@ function initHeroScene() {
     entrance.kill();
 
     gsap.set([firstLine, lastLine], { opacity: 1 });
-    gsap.set(photoWrap, { opacity: 1, scale: 1, '--hero-split-offset': '0px' });
+    gsap.set(photoWrap, { opacity: 1, scale: 1, '--hero-gap-open': '0px', '--hero-band-opacity': 0 });
     gsap.set(subtitle, { opacity: 1 });
   }
 
   function syncHeroToProgress(progress) {
+    var splitProgress = Math.max(0, Math.min((progress - 0.04) / 0.68, 1));
+    var bandProgress = Math.max(0, Math.min((splitProgress - 0.12) / 0.3, 1));
+
     gsap.set(firstLine, { opacity: 1, y: overlap - progress * spread });
     gsap.set(lastLine, { opacity: 1, y: -overlap + progress * spread });
     gsap.set(photoWrap, {
       opacity: 1,
       scale: 1 + progress * 0.012,
-      '--hero-split-offset': progress * splitDistance + 'px',
+      '--hero-gap-open': splitProgress * splitDistance + 'px',
+      '--hero-band-opacity': bandProgress,
     });
     gsap.set(subtitle, { opacity: 1 });
   }


### PR DESCRIPTION
## Summary
- split the hero portrait into top and bottom cropped halves and moved the credential line into the center reveal band
- updated hero styling so the centered band stays readable on desktop and mobile while preserving the existing poster-style name composition
- extended the existing GSAP hero scene to animate the split gap on scroll and keep the static fallback stable

## Verification
- `npm run check:syntax`
- `npx prettier --check /Users/rudrakshbhandari/.codex/worktrees/6315/mywebsite/index.html /Users/rudrakshbhandari/.codex/worktrees/6315/mywebsite/css/styles.css /Users/rudrakshbhandari/.codex/worktrees/6315/mywebsite/js/animations.js`
- local Playwright screenshots at desktop and mobile viewports against `http://127.0.0.1:4173/`
