### PR TITLE
fix(hero): bust cached asset URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
     </script>
 
     <!-- Custom CSS -->
-    <link rel="stylesheet" href="css/styles.css?v=2" />
+    <link rel="stylesheet" href="css/styles.css?v=3" />
 
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">
@@ -732,7 +732,7 @@
     <!-- JavaScript -->
     <script src="js/config.js"></script>
     <script src="js/analytics.js"></script>
-    <script src="js/main.js"></script>
-    <script src="js/animations.js"></script>
+    <script src="js/main.js?v=2"></script>
+    <script src="js/animations.js?v=2"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- bump the hero stylesheet URL from `styles.css?v=2` to `styles.css?v=3`
- bump `js/main.js` and `js/animations.js` URLs so browsers fetch the current hero behavior instead of mixing old cached assets with the new hero markup

## Verification
- `npm run check:syntax`
- `npx prettier --check index.html`
- inspected the live site HTML and confirmed the production hero issue matched a mixed cached-asset state
