### PR TITLE
fix(hero): restore pre-split hero layout

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -381,94 +381,22 @@ button:focus-visible {
 }
 
 .hero__photo-wrap {
-  --hero-photo-width: min(420px, 50vw);
-  --hero-photo-height: calc(var(--hero-photo-width) * 4 / 3);
-  --hero-gap-max: clamp(4rem, 5vw, 5.25rem);
-  --hero-gap-open: 0px;
-  --hero-band-opacity: 0;
-  --hero-split-point: 0.58;
   position: relative;
   z-index: 1;
-  width: var(--hero-photo-width);
-  height: calc(var(--hero-photo-height) + var(--hero-gap-max));
-  margin: -1.1em 0 -0.8em;
+  margin: -0.6em 0;
   will-change: transform, opacity;
 }
 
-.hero__photo-half {
-  position: absolute;
-  left: 0;
-  width: 100%;
-  height: calc(var(--hero-photo-height) * var(--hero-split-point));
-  overflow: hidden;
+.hero__photo {
+  width: min(420px, 50vw);
+  height: auto;
+  aspect-ratio: 3 / 4;
+  object-fit: cover;
+  object-position: 50% 25%;
+  border-radius: 14px;
   box-shadow:
     0 30px 80px rgba(0, 0, 0, 0.15),
     0 10px 25px rgba(0, 0, 0, 0.08);
-  will-change: transform;
-}
-
-.hero__photo-half--top {
-  top: 0;
-  border-radius: 14px 14px 0 0;
-  transform: translateY(calc((var(--hero-gap-max) - var(--hero-gap-open)) / 2));
-}
-
-.hero__photo-half--bottom {
-  bottom: 0;
-  height: calc(var(--hero-photo-height) * (1 - var(--hero-split-point)));
-  border-radius: 0 0 14px 14px;
-  transform: translateY(calc((var(--hero-gap-open) - var(--hero-gap-max)) / 2));
-}
-
-.hero__photo-fragment {
-  position: absolute;
-  left: 0;
-  width: 100%;
-  height: var(--hero-photo-height);
-  object-fit: cover;
-  object-position: 50% 25%;
-  display: block;
-}
-
-.hero__photo-fragment--top {
-  top: 0;
-}
-
-.hero__photo-fragment--bottom {
-  bottom: 0;
-}
-
-.hero__headline-band {
-  position: absolute;
-  inset-inline: clamp(0.8rem, 3vw, 1.25rem);
-  top: calc((var(--hero-photo-height) * var(--hero-split-point)) + (var(--hero-gap-max) / 2));
-  transform: translateY(-50%) scale(calc(0.96 + (var(--hero-band-opacity) * 0.04)));
-  min-height: clamp(3.2rem, 5vw, 4rem);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.7rem 1rem;
-  background: rgba(245, 240, 235, 0.88);
-  border-top: 1px solid rgba(28, 26, 24, 0.08);
-  border-bottom: 1px solid rgba(28, 26, 24, 0.08);
-  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.08);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
-  z-index: 3;
-  opacity: var(--hero-band-opacity);
-  pointer-events: none;
-}
-
-.hero__headline-band-text {
-  font-family: var(--font-display);
-  font-size: clamp(0.72rem, 1vw, 0.9rem);
-  font-weight: 700;
-  line-height: 1.4;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  text-align: center;
-  text-wrap: balance;
-  color: rgba(28, 26, 24, 0.82);
 }
 
 .hero__subtitle {
@@ -476,7 +404,7 @@ button:focus-visible {
   font-size: clamp(0.65rem, 1vw, 0.8rem);
   font-weight: 600;
   color: var(--color-text);
-  margin-top: 1.4rem;
+  margin-top: 2rem;
   position: relative;
   z-index: 2;
   letter-spacing: 0.12em;
@@ -498,7 +426,7 @@ button:focus-visible {
   opacity: 0.85;
 }
 
-.hero__subtitle-line--credentials {
+.hero__subtitle-line:not(.hero__subtitle-line--lede) {
   opacity: 0.45;
 }
 
@@ -1078,26 +1006,17 @@ button:focus-visible {
     font-size: clamp(2.8rem, 11vw, 5rem);
   }
 
-  .hero__photo-wrap {
-    --hero-photo-width: min(270px, 62vw);
-    --hero-gap-max: clamp(3.4rem, 10vw, 4.25rem);
-    margin: -0.7em 0 -0.45em;
-  }
-
-  .hero__headline-band {
-    inset-inline: 0.5rem;
-    padding: 0.65rem 0.75rem;
-  }
-
-  .hero__headline-band-text {
-    font-size: 0.62rem;
-    letter-spacing: 0.09em;
-  }
-
   .hero__subtitle {
     font-size: 0.68rem;
     letter-spacing: 0.08em;
-    margin-top: 1.15rem;
+  }
+
+  .hero__photo {
+    width: min(260px, 55vw);
+  }
+
+  .hero__photo-wrap {
+    margin: -0.4em 0;
   }
 
   /* About */
@@ -1200,13 +1119,12 @@ button:focus-visible {
     padding: 1.75rem;
   }
 
-  .hero__photo-wrap {
-    --hero-photo-width: min(224px, 62vw);
-    --hero-gap-max: 3.25rem;
+  .hero__photo {
+    width: min(220px, 55vw);
   }
 
-  .hero__headline-band-text {
-    font-size: 0.58rem;
+  .hero__photo-wrap {
+    margin: -0.3em 0;
   }
 }
 
@@ -1254,19 +1172,6 @@ button:focus-visible {
   .hero__inner {
     position: relative;
   }
-}
-
-.hero-static .hero__photo-wrap {
-  height: var(--hero-photo-height);
-}
-
-.hero-static .hero__photo-half--top,
-.hero-static .hero__photo-half--bottom {
-  transform: none;
-}
-
-.hero-static .hero__headline-band {
-  display: none;
 }
 
 /* =============================================

--- a/css/styles.css
+++ b/css/styles.css
@@ -386,9 +386,6 @@ button:focus-visible {
   --hero-gap-max: clamp(4rem, 5vw, 5.25rem);
   --hero-gap-open: 0px;
   --hero-band-opacity: 0;
-  --hero-line-one-opacity: 0;
-  --hero-line-two-opacity: 0;
-  --hero-line-three-opacity: 0;
   --hero-split-point: 0.58;
   position: relative;
   z-index: 1;
@@ -441,57 +438,37 @@ button:focus-visible {
   bottom: 0;
 }
 
-.hero__headline-window {
+.hero__headline-band {
   position: absolute;
   inset-inline: clamp(0.8rem, 3vw, 1.25rem);
-  top: calc(
-    (var(--hero-photo-height) * var(--hero-split-point)) + (var(--hero-gap-max) / 2) - (var(--hero-gap-open) / 2)
-  );
-  height: var(--hero-gap-open);
-  overflow: hidden;
+  top: calc((var(--hero-photo-height) * var(--hero-split-point)) + (var(--hero-gap-max) / 2));
+  transform: translateY(-50%) scale(calc(0.96 + (var(--hero-band-opacity) * 0.04)));
+  min-height: clamp(3.2rem, 5vw, 4rem);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.7rem 1rem;
+  background: rgba(245, 240, 235, 0.88);
+  border-top: 1px solid rgba(28, 26, 24, 0.08);
+  border-bottom: 1px solid rgba(28, 26, 24, 0.08);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.08);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
   z-index: 3;
+  opacity: var(--hero-band-opacity);
   pointer-events: none;
 }
 
-.hero__headline-band {
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 0.28rem;
-  padding: 0.55rem 1rem 0.65rem;
-  background: var(--color-bg);
-  opacity: var(--hero-band-opacity);
-  transform: translateY(calc((1 - var(--hero-band-opacity)) * 10px));
-}
-
-.hero__headline-line {
+.hero__headline-band-text {
   font-family: var(--font-display);
   font-size: clamp(0.72rem, 1vw, 0.9rem);
   font-weight: 700;
-  line-height: 1.15;
+  line-height: 1.4;
   letter-spacing: 0.14em;
   text-transform: uppercase;
   text-align: center;
   text-wrap: balance;
   color: rgba(28, 26, 24, 0.82);
-  transform: translateY(6px);
-}
-
-.hero__headline-line--one {
-  opacity: var(--hero-line-one-opacity);
-  transform: translateY(calc((1 - var(--hero-line-one-opacity)) * 6px));
-}
-
-.hero__headline-line--two {
-  opacity: var(--hero-line-two-opacity);
-  transform: translateY(calc((1 - var(--hero-line-two-opacity)) * 6px));
-}
-
-.hero__headline-line--three {
-  opacity: var(--hero-line-three-opacity);
-  transform: translateY(calc((1 - var(--hero-line-three-opacity)) * 6px));
 }
 
 .hero__subtitle {
@@ -1107,15 +1084,12 @@ button:focus-visible {
     margin: -0.7em 0 -0.45em;
   }
 
-  .hero__headline-window {
-    inset-inline: 0.5rem;
-  }
-
   .hero__headline-band {
-    padding: 0.55rem 0.75rem 0.6rem;
+    inset-inline: 0.5rem;
+    padding: 0.65rem 0.75rem;
   }
 
-  .hero__headline-line {
+  .hero__headline-band-text {
     font-size: 0.62rem;
     letter-spacing: 0.09em;
   }
@@ -1231,7 +1205,7 @@ button:focus-visible {
     --hero-gap-max: 3.25rem;
   }
 
-  .hero__headline-line {
+  .hero__headline-band-text {
     font-size: 0.58rem;
   }
 }
@@ -1291,7 +1265,7 @@ button:focus-visible {
   transform: none;
 }
 
-.hero-static .hero__headline-window {
+.hero-static .hero__headline-band {
   display: none;
 }
 

--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
     </script>
 
     <!-- Custom CSS -->
-    <link rel="stylesheet" href="css/styles.css?v=3" />
+    <link rel="stylesheet" href="css/styles.css?v=2" />
 
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">
@@ -169,43 +169,27 @@
         <div class="hero__inner">
           <h1 class="hero__name" aria-label="Rudraksh Bhandari">
             <span class="hero__line hero__line--first">Rudraksh</span>
-            <div class="hero__photo-wrap" role="img" aria-label="Rudraksh Bhandari">
-              <div class="hero__photo-half hero__photo-half--top" aria-hidden="true">
-                <img
-                  src="img/Rudraksh-8-600.jpg"
-                  srcset="img/Rudraksh-8-600.jpg 600w, img/Rudraksh-8-1200.jpg 1200w"
-                  sizes="(max-width: 768px) 260px, 420px"
-                  alt=""
-                  class="hero__photo-fragment hero__photo-fragment--top"
-                  width="420"
-                  height="560"
-                  fetchpriority="high"
-                  decoding="async"
-                />
-              </div>
-              <div class="hero__headline-band">
-                <span class="hero__headline-band-text"
-                  >ML Researcher @ UCSD · 2x SDE Intern @ AWS · Building NomNom and Outfitr</span
-                >
-              </div>
-              <div class="hero__photo-half hero__photo-half--bottom" aria-hidden="true">
-                <img
-                  src="img/Rudraksh-8-600.jpg"
-                  srcset="img/Rudraksh-8-600.jpg 600w, img/Rudraksh-8-1200.jpg 1200w"
-                  sizes="(max-width: 768px) 260px, 420px"
-                  alt=""
-                  class="hero__photo-fragment hero__photo-fragment--bottom"
-                  width="420"
-                  height="560"
-                  decoding="async"
-                />
-              </div>
+            <div class="hero__photo-wrap">
+              <img
+                src="img/Rudraksh-8-600.jpg"
+                srcset="img/Rudraksh-8-600.jpg 600w, img/Rudraksh-8-1200.jpg 1200w"
+                sizes="(max-width: 768px) 260px, 420px"
+                alt="Rudraksh Bhandari"
+                class="hero__photo"
+                width="420"
+                height="560"
+                fetchpriority="high"
+                decoding="async"
+              />
             </div>
             <span class="hero__line hero__line--last">Bhandari</span>
           </h1>
           <p class="hero__subtitle">
             <span class="hero__subtitle-line hero__subtitle-line--lede"
               >Machine learning, mobile systems, and public-interest software</span
+            >
+            <span class="hero__subtitle-line"
+              >ML Researcher @ UCSD · 2x SDE Intern @ AWS · Building NomNom and Outfitr</span
             >
           </p>
         </div>
@@ -732,7 +716,7 @@
     <!-- JavaScript -->
     <script src="js/config.js"></script>
     <script src="js/analytics.js"></script>
-    <script src="js/main.js?v=2"></script>
-    <script src="js/animations.js?v=2"></script>
+    <script src="js/main.js"></script>
+    <script src="js/animations.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -183,12 +183,10 @@
                   decoding="async"
                 />
               </div>
-              <div class="hero__headline-window">
-                <div class="hero__headline-band">
-                  <span class="hero__headline-line hero__headline-line--one">ML Researcher @ UCSD</span>
-                  <span class="hero__headline-line hero__headline-line--two">2x SDE Intern @ AWS</span>
-                  <span class="hero__headline-line hero__headline-line--three">Building NomNom and Outfitr</span>
-                </div>
+              <div class="hero__headline-band">
+                <span class="hero__headline-band-text"
+                  >ML Researcher @ UCSD · 2x SDE Intern @ AWS · Building NomNom and Outfitr</span
+                >
               </div>
               <div class="hero__photo-half hero__photo-half--bottom" aria-hidden="true">
                 <img

--- a/js/animations.js
+++ b/js/animations.js
@@ -39,14 +39,10 @@ document.addEventListener('DOMContentLoaded', function () {
 function initStaticFallback() {
   var heroLines = document.querySelectorAll('.hero__line');
   var heroPhotoWrap = document.querySelector('.hero__photo-wrap');
-  var heroHeadlineBand = document.querySelector('.hero__headline-band');
-  var heroHeadlineBandText = document.querySelector('.hero__headline-band-text');
   var heroSubtitle = document.querySelector('.hero__subtitle');
   var paragraphs = document.querySelectorAll('.about__paragraph');
   var projCards = document.querySelectorAll('.proj-card');
   var projImages = document.querySelectorAll('.projects__img');
-
-  document.body.classList.add('hero-static');
 
   heroLines.forEach(function (line) {
     line.style.opacity = '1';
@@ -55,22 +51,9 @@ function initStaticFallback() {
   if (heroPhotoWrap) {
     heroPhotoWrap.style.opacity = '1';
     heroPhotoWrap.style.transform = 'none';
-    heroPhotoWrap.style.setProperty('--hero-gap-open', '0px');
-    heroPhotoWrap.style.setProperty('--hero-band-opacity', '0');
   }
   if (heroSubtitle) {
     heroSubtitle.style.opacity = '1';
-  }
-  if (
-    heroHeadlineBand &&
-    heroHeadlineBandText &&
-    heroSubtitle &&
-    !heroSubtitle.querySelector('.hero__subtitle-line--credentials')
-  ) {
-    var credentialsLine = document.createElement('span');
-    credentialsLine.className = 'hero__subtitle-line hero__subtitle-line--credentials';
-    credentialsLine.textContent = heroHeadlineBandText.textContent;
-    heroSubtitle.appendChild(credentialsLine);
   }
 
   paragraphs.forEach(function (p) {
@@ -102,9 +85,8 @@ function initHeroScene() {
   if (!heroSection || !heroInner || !firstLine || !lastLine || !photoWrap) return;
 
   /* --- Entrance: elements land in a tight, overlapping position --- */
-  var overlap = 42;
-  var spread = overlap + 26;
-  var splitDistance = 84;
+  var overlap = 50;
+  var spread = overlap + 20;
   var entranceSettled = false;
 
   function finishEntrance() {
@@ -114,22 +96,14 @@ function initHeroScene() {
     entrance.kill();
 
     gsap.set([firstLine, lastLine], { opacity: 1 });
-    gsap.set(photoWrap, { opacity: 1, scale: 1, '--hero-gap-open': '0px', '--hero-band-opacity': 0 });
+    gsap.set(photoWrap, { opacity: 1, scale: 1 });
     gsap.set(subtitle, { opacity: 1 });
   }
 
   function syncHeroToProgress(progress) {
-    var splitProgress = Math.max(0, Math.min((progress - 0.04) / 0.68, 1));
-    var bandProgress = Math.max(0, Math.min((splitProgress - 0.12) / 0.3, 1));
-
     gsap.set(firstLine, { opacity: 1, y: overlap - progress * spread });
     gsap.set(lastLine, { opacity: 1, y: -overlap + progress * spread });
-    gsap.set(photoWrap, {
-      opacity: 1,
-      scale: 1 + progress * 0.012,
-      '--hero-gap-open': splitProgress * splitDistance + 'px',
-      '--hero-band-opacity': bandProgress,
-    });
+    gsap.set(photoWrap, { opacity: 1, scale: 1 + progress * 0.015 });
     gsap.set(subtitle, { opacity: 1 });
   }
 

--- a/js/animations.js
+++ b/js/animations.js
@@ -40,6 +40,7 @@ function initStaticFallback() {
   var heroLines = document.querySelectorAll('.hero__line');
   var heroPhotoWrap = document.querySelector('.hero__photo-wrap');
   var heroHeadlineBand = document.querySelector('.hero__headline-band');
+  var heroHeadlineBandText = document.querySelector('.hero__headline-band-text');
   var heroSubtitle = document.querySelector('.hero__subtitle');
   var paragraphs = document.querySelectorAll('.about__paragraph');
   var projCards = document.querySelectorAll('.proj-card');
@@ -56,17 +57,19 @@ function initStaticFallback() {
     heroPhotoWrap.style.transform = 'none';
     heroPhotoWrap.style.setProperty('--hero-gap-open', '0px');
     heroPhotoWrap.style.setProperty('--hero-band-opacity', '0');
-    heroPhotoWrap.style.setProperty('--hero-line-one-opacity', '0');
-    heroPhotoWrap.style.setProperty('--hero-line-two-opacity', '0');
-    heroPhotoWrap.style.setProperty('--hero-line-three-opacity', '0');
   }
   if (heroSubtitle) {
     heroSubtitle.style.opacity = '1';
   }
-  if (heroHeadlineBand && heroSubtitle && !heroSubtitle.querySelector('.hero__subtitle-line--credentials')) {
+  if (
+    heroHeadlineBand &&
+    heroHeadlineBandText &&
+    heroSubtitle &&
+    !heroSubtitle.querySelector('.hero__subtitle-line--credentials')
+  ) {
     var credentialsLine = document.createElement('span');
     credentialsLine.className = 'hero__subtitle-line hero__subtitle-line--credentials';
-    credentialsLine.textContent = heroHeadlineBand.textContent.replace(/\s+/g, ' ').trim();
+    credentialsLine.textContent = heroHeadlineBandText.textContent;
     heroSubtitle.appendChild(credentialsLine);
   }
 
@@ -111,36 +114,21 @@ function initHeroScene() {
     entrance.kill();
 
     gsap.set([firstLine, lastLine], { opacity: 1 });
-    gsap.set(photoWrap, {
-      opacity: 1,
-      scale: 1,
-      '--hero-gap-open': '0px',
-      '--hero-band-opacity': 0,
-      '--hero-line-one-opacity': 0,
-      '--hero-line-two-opacity': 0,
-      '--hero-line-three-opacity': 0,
-    });
+    gsap.set(photoWrap, { opacity: 1, scale: 1, '--hero-gap-open': '0px', '--hero-band-opacity': 0 });
     gsap.set(subtitle, { opacity: 1 });
   }
 
   function syncHeroToProgress(progress) {
     var splitProgress = Math.max(0, Math.min((progress - 0.04) / 0.68, 1));
-    var gapOpen = splitProgress * splitDistance;
-    var bandProgress = Math.max(0, Math.min((gapOpen - 20) / 16, 1));
-    var lineOneProgress = Math.max(0, Math.min((gapOpen - 20) / 10, 1));
-    var lineTwoProgress = Math.max(0, Math.min((gapOpen - 36) / 10, 1));
-    var lineThreeProgress = Math.max(0, Math.min((gapOpen - 52) / 10, 1));
+    var bandProgress = Math.max(0, Math.min((splitProgress - 0.12) / 0.3, 1));
 
     gsap.set(firstLine, { opacity: 1, y: overlap - progress * spread });
     gsap.set(lastLine, { opacity: 1, y: -overlap + progress * spread });
     gsap.set(photoWrap, {
       opacity: 1,
       scale: 1 + progress * 0.012,
-      '--hero-gap-open': gapOpen + 'px',
+      '--hero-gap-open': splitProgress * splitDistance + 'px',
       '--hero-band-opacity': bandProgress,
-      '--hero-line-one-opacity': lineOneProgress,
-      '--hero-line-two-opacity': lineTwoProgress,
-      '--hero-line-three-opacity': lineThreeProgress,
     });
     gsap.set(subtitle, { opacity: 1 });
   }


### PR DESCRIPTION
## Summary
- roll back the live hero to the last pre-split layout
- restore the intact portrait and put the credential line back below the hero image

## Validation
- npm run check:syntax
- npx prettier --check index.html css/styles.css js/animations.js
