### PR TITLE
fix(stats): use CF rum_site_id as siteTag + add outfitr/nyaaywatch

### DIFF
--- a/scripts/fetch_stats.mjs
+++ b/scripts/fetch_stats.mjs
@@ -87,16 +87,16 @@ async function fetchCloudflareVisitors() {
   const sites = collectCloudflareSites();
   const end = new Date();
   const start = new Date(end.getTime() - 30 * 24 * 60 * 60 * 1000);
-  const startStr = start.toISOString().slice(0, 10);
-  const endStr = end.toISOString().slice(0, 10);
+  const startStr = start.toISOString();
+  const endStr = end.toISOString();
 
   const query = `
-    query ($accountTag: String!, $siteTag: String!, $start: Date!, $end: Date!) {
+    query ($accountTag: String!, $siteTag: String!, $start: Time!, $end: Time!) {
       viewer {
         accounts(filter: { accountTag: $accountTag }) {
           rumPageloadEventsAdaptiveGroups(
             limit: 10000
-            filter: { siteTag: $siteTag, date_geq: $start, date_leq: $end }
+            filter: { siteTag: $siteTag, datetime_geq: $start, datetime_leq: $end }
           ) {
             count
             sum { visits }

--- a/scripts/fetch_stats.mjs
+++ b/scripts/fetch_stats.mjs
@@ -133,12 +133,19 @@ async function fetchCloudflareVisitors() {
         console.warn(`[cf] ${site.domain}: API errors ${JSON.stringify(parsed.errors)}`);
         continue;
       }
-      const groups = parsed.data?.viewer?.accounts?.[0]?.rumPageloadEventsAdaptiveGroups ?? [];
+      const accounts = parsed.data?.viewer?.accounts ?? [];
+      if (accounts.length === 0) {
+        console.warn(`[cf] ${site.domain}: no accounts matched — accountTag likely wrong`);
+      }
+      const groups = accounts[0]?.rumPageloadEventsAdaptiveGroups ?? [];
       let visits = 0;
       let pageviews = 0;
       for (const g of groups) {
         visits += g.sum?.visits ?? 0;
         pageviews += g.count ?? 0;
+      }
+      if (groups.length === 0 || visits === 0) {
+        console.warn(`[cf] ${site.domain}: groups=${groups.length} visits=${visits} raw=${res.body.toString('utf8').slice(0, 400)}`);
       }
       results[site.domain] = { visits, pageviews };
       totalVisits += visits;

--- a/scripts/fetch_stats.mjs
+++ b/scripts/fetch_stats.mjs
@@ -34,14 +34,14 @@ const PLAY_APPS = [{ packageName: 'com.rudraksh99.ShareAllBooks', label: 'ShareA
 
 // --- Cloudflare sites to aggregate --------------------------------------
 //
-// siteTag values are the same tokens embedded in the beacon `data-cf-beacon`
-// attribute across each site.
+// siteTag here is the CF internal rum_site_id (from the dashboard URL
+// /web-analytics/edit/<id>), NOT the data-cf-beacon token.
 const CF_SITES = [
-  { domain: 'rudrakshbhandari.com', siteTag: '7045f28413c9496d933d2299661cfc69' },
-  { domain: 'nomnom.cc', siteTag: '70f00ab34ee944268c6face29ab89662' },
-  { domain: 'shareallbooks.com', siteTag: 'db45abbb06fc456eafeb24ef9a54a216' },
-  // outfitr.net + nyaaywatch.in are CF-proxied (Automatic mode) — populated
-  // when CF_EXTRA_SITE_TAGS env var is set, formatted "domain:siteTag,...".
+  { domain: 'rudrakshbhandari.com', siteTag: 'fd83acce982749c98c424495b1e0625e' },
+  { domain: 'nomnom.cc', siteTag: 'a2bb6225092b406e9c9f41535fbccc7e' },
+  { domain: 'shareallbooks.com', siteTag: '2b4d2bbf2cec4c84b2e326865428f7cf' },
+  { domain: 'outfitr.net', siteTag: '1671c0d8d5c34790ab61905758858b3f' },
+  { domain: 'nyaaywatch.in', siteTag: '47d9aae9eb974d33a4ac4a2c7a07644f' },
 ];
 
 // --- HTTP helper --------------------------------------------------------
@@ -133,19 +133,12 @@ async function fetchCloudflareVisitors() {
         console.warn(`[cf] ${site.domain}: API errors ${JSON.stringify(parsed.errors)}`);
         continue;
       }
-      const accounts = parsed.data?.viewer?.accounts ?? [];
-      if (accounts.length === 0) {
-        console.warn(`[cf] ${site.domain}: no accounts matched — accountTag likely wrong`);
-      }
-      const groups = accounts[0]?.rumPageloadEventsAdaptiveGroups ?? [];
+      const groups = parsed.data?.viewer?.accounts?.[0]?.rumPageloadEventsAdaptiveGroups ?? [];
       let visits = 0;
       let pageviews = 0;
       for (const g of groups) {
         visits += g.sum?.visits ?? 0;
         pageviews += g.count ?? 0;
-      }
-      if (groups.length === 0 || visits === 0) {
-        console.warn(`[cf] ${site.domain}: groups=${groups.length} visits=${visits} raw=${res.body.toString('utf8').slice(0, 400)}`);
       }
       results[site.domain] = { visits, pageviews };
       totalVisits += visits;


### PR DESCRIPTION
Our GraphQL filter was using the beacon `data-cf-beacon` token, but CF's `rumPageloadEventsAdaptiveGroups` filter expects the internal rum_site_id (the ID in the dashboard edit URL). Swapping to those IDs makes visits populate; also adds outfitr.net + nyaaywatch.in which are Automatic-mode sites in CF.