### PR TITLE
fix(csp): allow Cloudflare Web Analytics beacon

### DIFF
--- a/case-studies/index.html
+++ b/case-studies/index.html
@@ -7,7 +7,7 @@
     <meta name="author" content="Rudraksh Bhandari" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; base-uri 'self'; object-src 'none'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com https://cdnjs.cloudflare.com; script-src 'self' https://www.googletagmanager.com; connect-src 'self' https://www.google-analytics.com https://region1.google-analytics.com; form-action 'self'; upgrade-insecure-requests"
+      content="default-src 'self'; base-uri 'self'; object-src 'none'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com https://cdnjs.cloudflare.com; script-src 'self' https://www.googletagmanager.com https://static.cloudflareinsights.com; connect-src 'self' https://www.google-analytics.com https://region1.google-analytics.com https://cloudflareinsights.com; form-action 'self'; upgrade-insecure-requests"
     />
 
     <link rel="canonical" href="https://rudrakshbhandari.com/case-studies" />

--- a/health/index.html
+++ b/health/index.html
@@ -7,7 +7,7 @@
     <meta name="author" content="Rudraksh Bhandari" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; base-uri 'self'; object-src 'none'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com https://cdnjs.cloudflare.com; script-src 'self' https://www.googletagmanager.com; connect-src 'self' https://www.google-analytics.com https://region1.google-analytics.com; form-action 'self'; upgrade-insecure-requests"
+      content="default-src 'self'; base-uri 'self'; object-src 'none'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com https://cdnjs.cloudflare.com; script-src 'self' https://www.googletagmanager.com https://static.cloudflareinsights.com; connect-src 'self' https://www.google-analytics.com https://region1.google-analytics.com https://cloudflareinsights.com; form-action 'self'; upgrade-insecure-requests"
     />
 
     <!-- Canonical URL -->

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <meta name="author" content="Rudraksh Bhandari" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; base-uri 'self'; object-src 'none'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com https://cdnjs.cloudflare.com; script-src 'self' 'sha256-rR/RWSAasE0jjLwGOkGLI+gwWMtoC1now33sqjmfbs0=' 'sha256-zQU6HeLTQX9XpXyeu63kgl9FHETbFcqviKDFhjdm3pM=' https://cdnjs.cloudflare.com https://www.googletagmanager.com; connect-src 'self' https://www.google-analytics.com https://region1.google-analytics.com; form-action 'self'; upgrade-insecure-requests"
+      content="default-src 'self'; base-uri 'self'; object-src 'none'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com https://cdnjs.cloudflare.com; script-src 'self' 'sha256-rR/RWSAasE0jjLwGOkGLI+gwWMtoC1now33sqjmfbs0=' 'sha256-zQU6HeLTQX9XpXyeu63kgl9FHETbFcqviKDFhjdm3pM=' https://cdnjs.cloudflare.com https://www.googletagmanager.com https://static.cloudflareinsights.com; connect-src 'self' https://www.google-analytics.com https://region1.google-analytics.com https://cloudflareinsights.com; form-action 'self'; upgrade-insecure-requests"
     />
 
     <!-- Canonical URL -->

--- a/notes/index.html
+++ b/notes/index.html
@@ -10,7 +10,7 @@
     <meta name="author" content="Rudraksh Bhandari" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; base-uri 'self'; object-src 'none'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com https://cdnjs.cloudflare.com; script-src 'self' https://www.googletagmanager.com; connect-src 'self' https://www.google-analytics.com https://region1.google-analytics.com; form-action 'self'; upgrade-insecure-requests"
+      content="default-src 'self'; base-uri 'self'; object-src 'none'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com https://cdnjs.cloudflare.com; script-src 'self' https://www.googletagmanager.com https://static.cloudflareinsights.com; connect-src 'self' https://www.google-analytics.com https://region1.google-analytics.com https://cloudflareinsights.com; form-action 'self'; upgrade-insecure-requests"
     />
 
     <link rel="canonical" href="https://rudrakshbhandari.com/notes" />


### PR DESCRIPTION
## Summary
- Root cause of rudrakshbhandari.com showing 0 visits in CF Web Analytics: the CSP meta tag in each HTML file was blocking the beacon script.
- Added `https://static.cloudflareinsights.com` to `script-src` and `https://cloudflareinsights.com` to `connect-src` so the beacon can load and POST events.

## Test plan
- [ ] After merge, load rudrakshbhandari.com in a browser and confirm `static.cloudflareinsights.com/beacon.min.js` returns 200 (not CSP-blocked → 503).
- [ ] Wait a few minutes and confirm `rumPageloadEventsAdaptiveGroups` GraphQL returns non-zero visits for siteTag `fd83acce982749c98c424495b1e0625e`.