### PR TITLE
fix(stats): use correct Play Reporting API endpoint

### DIFF
--- a/scripts/fetch_stats.mjs
+++ b/scripts/fetch_stats.mjs
@@ -423,7 +423,7 @@ async function fetchPlayInstallsForApp({ accessToken, packageName }) {
     {
       method: 'POST',
       hostname: 'playdeveloperreporting.googleapis.com',
-      path: `/v1beta1/apps/${encodeURIComponent(packageName)}/installsTimelineSeries:query`,
+      path: `/v1beta1/apps/${encodeURIComponent(packageName)}/installsStats:query`,
       headers: {
         Authorization: `Bearer ${accessToken}`,
         'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- Switch Play Developer Reporting API path from `installsTimelineSeries:query` to `installsStats:query` — the former returned an HTML 404, the latter is the documented endpoint.

## Test plan
- [ ] CI green
- [ ] After merge, manually trigger stats-update workflow and verify `androidInstalls` is non-null for `com.rudraksh99.ShareAllBooks`