### PR TITLE
chore(stats): refresh portfolio stats [2026-04-24]

### DIFF
--- a/stats_public.json
+++ b/stats_public.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "2026-04-24T00:25:55.992Z",
+  "lastUpdated": "2026-04-24T00:29:19.182Z",
   "sources": {
     "cloudflare": "ok",
     "appStore": "ok",
@@ -21,8 +21,8 @@
   },
   "websiteVisitors": {
     "windowDays": 30,
-    "windowStart": "2026-03-25T00:25:49.406Z",
-    "windowEnd": "2026-04-24T00:25:49.406Z",
+    "windowStart": "2026-03-25T00:29:12.689Z",
+    "windowEnd": "2026-04-24T00:29:12.689Z",
     "totalVisits": 990,
     "totalPageviews": 1100,
     "perSite": {


### PR DESCRIPTION
Automated portfolio stats refresh (downloads + website visitors).