### PR TITLE
feat(stats): dynamic download counts + ratchet against decrements

### DIFF
--- a/index.html
+++ b/index.html
@@ -236,7 +236,9 @@
                 class="text-link"
                 >featured in national press</a
               >
-              that reached 2K+ downloads and 1,500+ book transactions.
+              that reached
+              <span data-stat="shareallbooks-downloads" data-stat-format="compact-plus">2K+</span> downloads and 1,500+
+              book transactions.
             </p>
 
             <p class="about__paragraph">
@@ -251,7 +253,13 @@
                 <span class="about__stat-label">GPA @ UCSD</span>
               </div>
               <div class="about__stat">
-                <span class="about__stat-number" data-target="2K+">2K+</span>
+                <span
+                  class="about__stat-number"
+                  data-target="2K+"
+                  data-stat="shareallbooks-downloads"
+                  data-stat-format="compact-plus"
+                  >2K+</span
+                >
                 <span class="about__stat-label">App Downloads</span>
               </div>
               <div class="about__stat">
@@ -355,7 +363,8 @@
               <p class="exp-card__location">United Arab Emirates</p>
               <ul class="exp-card__bullets">
                 <li>
-                  Founded and launched a book-sharing mobile app (App Store & Play Store), reaching 2K+ downloads within
+                  Founded and launched a book-sharing mobile app (App Store & Play Store), reaching
+                  <span data-stat="shareallbooks-downloads" data-stat-format="compact-plus">2K+</span> downloads within
                   the first year.
                 </li>
                 <li>
@@ -486,7 +495,8 @@
             <article class="proj-card" data-project="3">
               <h3 class="proj-card__title">ShareAllBooks</h3>
               <p class="proj-card__metric">
-                2K+ installs · 1,500+ book transactions ·
+                <span data-stat="shareallbooks-downloads" data-stat-format="compact-plus">2K+</span> installs · 1,500+
+                book transactions ·
                 <a
                   href="https://www.khaleejtimes.com/uae/dubai-student-creates-app-for-free-exchange-of-books"
                   target="_blank"

--- a/scripts/fetch_stats.mjs
+++ b/scripts/fetch_stats.mjs
@@ -596,18 +596,46 @@ function loadPrevious() {
   }
 }
 
+// Ratchet: cumulative counts (installs, downloads) can only go up.
+// If a fresh value is lower than the stored one, keep the stored one and warn.
+// This catches partial-fetch bugs — a real count never decreases because
+// uninstalls are not subtracted ("downloaded + uninstalled = 1").
+function ratchet(key, freshVal, prevVal) {
+  if (freshVal == null) return prevVal ?? null;
+  if (prevVal == null) return freshVal;
+  if (freshVal < prevVal) {
+    console.warn(`[ratchet] ${key}: fresh=${freshVal} < prev=${prevVal} — keeping previous`);
+    return prevVal;
+  }
+  return freshVal;
+}
+
 function mergeApps({ previous, apple, play }) {
-  const shareAllBooksApple = apple?.['6457063516']?.iosDownloads ?? previous?.apps?.shareallbooks?.iosDownloads ?? null;
-  const shareAllBooksPlay =
-    play?.['com.rudraksh99.ShareAllBooks']?.androidInstalls ?? previous?.apps?.shareallbooks?.androidInstalls ?? null;
-  const nomnomRiderApple = apple?.['6760152698']?.iosDownloads ?? previous?.apps?.nomnomRider?.iosDownloads ?? null;
+  const prevSAB = previous?.apps?.shareallbooks;
+  const prevNNR = previous?.apps?.nomnomRider;
+
+  const shareAllBooksApple = ratchet(
+    'shareallbooks.iosDownloads',
+    apple?.['6457063516']?.iosDownloads ?? null,
+    prevSAB?.iosDownloads ?? null
+  );
+  const shareAllBooksPlay = ratchet(
+    'shareallbooks.androidInstalls',
+    play?.['com.rudraksh99.ShareAllBooks']?.androidInstalls ?? null,
+    prevSAB?.androidInstalls ?? null
+  );
+  const nomnomRiderApple = ratchet(
+    'nomnomRider.iosDownloads',
+    apple?.['6760152698']?.iosDownloads ?? null,
+    prevNNR?.iosDownloads ?? null
+  );
 
   const shareAllBooksTotal =
     shareAllBooksApple != null || shareAllBooksPlay != null
       ? (shareAllBooksApple ?? 0) + (shareAllBooksPlay ?? 0)
-      : (previous?.apps?.shareallbooks?.total ?? null);
+      : (prevSAB?.total ?? null);
 
-  const nomnomRiderTotal = nomnomRiderApple != null ? nomnomRiderApple : (previous?.apps?.nomnomRider?.total ?? null);
+  const nomnomRiderTotal = nomnomRiderApple != null ? nomnomRiderApple : (prevNNR?.total ?? null);
 
   return {
     shareallbooks: {

--- a/work/index.html
+++ b/work/index.html
@@ -204,8 +204,9 @@
               <p class="work-card__meta">Founder · 2023 - 2024</p>
               <h3>ShareAllBooks</h3>
               <p>
-                UAE book-sharing app launched on App Store and Play Store, reaching 2,000+ downloads, 1,500+
-                donations/sales, and national press coverage.
+                UAE book-sharing app launched on App Store and Play Store, reaching
+                <span data-stat="shareallbooks-downloads" data-stat-format="thousands-plus">2,000+</span> downloads,
+                1,500+ donations/sales, and national press coverage.
               </p>
               <a href="https://www.shareallbooks.com" target="_blank" rel="noopener noreferrer" class="proj-card__link"
                 >Visit shareallbooks.com →</a


### PR DESCRIPTION
## Summary
- Replaces hardcoded \"2K+\" / \"2,000+\" in `index.html` (×4) and `work/index.html` (×1) with `data-stat` spans driven by `stats_public.json`
- Adds `ratchet()` helper in `fetch_stats.mjs`: cumulative install counts can only go up — if a fresh fetch returns a lower total than the stored value, the stored value is kept and a warning is logged
- Ratchet is applied per-component (iOS downloads, Android installs) before the per-app total is computed

## Why ratchet?
App stores never decrement install counts for uninstalls. If a fetch returns a lower number it means something broke (API outage, auth failure, partial data). Keeping the previous value ensures the displayed stat is always the legitimate historical high-water mark.

## Test plan
- [ ] `stats_public.json` has `apps.shareallbooks.total` ≥ 1921 → rendered page shows that number (formatted) instead of hardcoded fallback
- [ ] Simulate a lower fresh value in a manual run: logs should show `[ratchet] … keeping previous`