### PR TITLE
fix(health): touch scrolling, safe-area layout, and tap targets

### DIFF
--- a/health/index.html
+++ b/health/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content="Health Metrics - Oura Ring Data | Rudraksh Bhandari" />
     <meta name="author" content="Rudraksh Bhandari" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; base-uri 'self'; object-src 'none'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com https://cdnjs.cloudflare.com; script-src 'self' https://www.googletagmanager.com https://static.cloudflareinsights.com; connect-src 'self' https://www.google-analytics.com https://region1.google-analytics.com https://cloudflareinsights.com; form-action 'self'; upgrade-insecure-requests"
+      content="default-src 'self'; base-uri 'self'; object-src 'none'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com https://cdnjs.cloudflare.com; script-src 'self' https://www.googletagmanager.com; connect-src 'self' https://www.google-analytics.com https://region1.google-analytics.com; form-action 'self'; upgrade-insecure-requests"
     />
 
     <!-- Canonical URL -->
@@ -84,6 +84,7 @@
         color: var(--text-primary);
         background: var(--background-dark);
         min-height: 100vh;
+        min-height: 100dvh;
         overflow-x: hidden;
       }
 
@@ -114,7 +115,8 @@
       .nav-container {
         max-width: 1200px;
         margin: 0 auto;
-        padding: 1rem 1.5rem;
+        padding: calc(1rem + env(safe-area-inset-top, 0px)) calc(1.5rem + env(safe-area-inset-right, 0px)) 1rem
+          calc(1.5rem + env(safe-area-inset-left, 0px));
         display: flex;
         align-items: center;
         justify-content: space-between;
@@ -148,7 +150,7 @@
       main {
         max-width: 1200px;
         margin: 0 auto;
-        padding: 7rem 1.5rem 4rem;
+        padding: 7rem calc(1.5rem + env(safe-area-inset-right, 0px)) 4rem calc(1.5rem + env(safe-area-inset-left, 0px));
       }
 
       .page-header {
@@ -700,6 +702,7 @@
         width: 100%;
         height: 220px;
         display: block;
+        touch-action: pan-y;
       }
 
       .timeline-axis-label {
@@ -1042,7 +1045,8 @@
       footer {
         max-width: 1200px;
         margin: 0 auto;
-        padding: 2rem 1.5rem;
+        padding: 2rem calc(1.5rem + env(safe-area-inset-right, 0px)) calc(2rem + env(safe-area-inset-bottom, 0px))
+          calc(1.5rem + env(safe-area-inset-left, 0px));
         border-top: 1px solid var(--border-color);
         display: flex;
         flex-wrap: wrap;
@@ -1151,6 +1155,7 @@
         align-items: flex-end;
         gap: 0.5rem;
         height: 100%;
+        overscroll-behavior-x: contain;
       }
 
       .trend-day {
@@ -1319,6 +1324,34 @@
           font-size: 2rem;
         }
 
+        main {
+          padding-top: calc(5.5rem + env(safe-area-inset-top, 0px));
+          padding-bottom: calc(2.75rem + env(safe-area-inset-bottom, 0px));
+        }
+
+        .page-header {
+          margin-bottom: 2rem;
+        }
+
+        .nav-logo a {
+          font-size: 1.1rem;
+        }
+
+        .nav-back {
+          min-height: 44px;
+          padding: 0.4rem 0.6rem;
+          align-items: center;
+          -webkit-tap-highlight-color: transparent;
+        }
+
+        .metric-card {
+          padding: 1.25rem;
+        }
+
+        .timeline-svg {
+          height: 200px;
+        }
+
         .timeline-stats {
           grid-template-columns: repeat(2, minmax(0, 1fr));
         }
@@ -1350,9 +1383,11 @@
           padding-bottom: 0.5rem;
           -webkit-overflow-scrolling: touch;
           height: 140px;
+          touch-action: pan-x pan-y;
         }
 
         .trend-day {
+          flex: 0 0 auto;
           min-width: 44px;
         }
 

--- a/js/health.js
+++ b/js/health.js
@@ -788,13 +788,43 @@ function renderHeartRateTimeline(series, data) {
     svgEl.onmousemove = e => findNearestAndUpdate(e.clientX, e.clientY);
     svgEl.onmouseleave = hideTracking;
 
-    // Touch support for mobile
-    svgEl.ontouchmove = e => {
-      e.preventDefault();
-      const touch = e.touches[0];
-      findNearestAndUpdate(touch.clientX, touch.clientY);
+    // Mobile: only hijack the gesture when the user is clearly scrubbing horizontally.
+    // Unconditional preventDefault on touchmove made vertical page scroll almost impossible on the chart.
+    let hrTouchStart = null;
+    let hrTouchMode = null;
+    const HR_GESTURE_PX = 12;
+
+    svgEl.ontouchstart = e => {
+      if (e.touches.length !== 1) return;
+      const t = e.touches[0];
+      hrTouchStart = { x: t.clientX, y: t.clientY };
+      hrTouchMode = null;
     };
-    svgEl.ontouchend = hideTracking;
+
+    svgEl.ontouchmove = e => {
+      if (!hrTouchStart || e.touches.length !== 1) return;
+      const t = e.touches[0];
+      const dx = t.clientX - hrTouchStart.x;
+      const dy = t.clientY - hrTouchStart.y;
+
+      if (hrTouchMode === null) {
+        if (Math.abs(dx) < HR_GESTURE_PX && Math.abs(dy) < HR_GESTURE_PX) return;
+        hrTouchMode = Math.abs(dy) > Math.abs(dx) + 4 ? 'scroll' : 'scrub';
+      }
+
+      if (hrTouchMode === 'scrub') {
+        e.preventDefault();
+        findNearestAndUpdate(t.clientX, t.clientY);
+      }
+    };
+
+    const endHrTouch = () => {
+      hrTouchStart = null;
+      hrTouchMode = null;
+      hideTracking();
+    };
+    svgEl.ontouchend = endHrTouch;
+    svgEl.ontouchcancel = endHrTouch;
   }
 
   const minEl = document.getElementById('heart-rate-min');


### PR DESCRIPTION
## Summary

Health-dashboard-only subset extracted from the stale #265 (portfolio side already landed via #267 and #332).

- **Heart rate chart:** touch handler now distinguishes scroll vs. scrub — mostly-vertical touches pass through as page scroll instead of blocking with `preventDefault()` on every `touchmove`
- **7-day trends strip:** `touch-action: pan-x pan-y` + `overscroll-behavior-x: contain` for predictable nested horizontal scroll
- **Layout:** `viewport-fit=cover`, safe-area inset padding on header/main/footer, `100dvh` min-height
- **Back link:** 44px minimum tap target

## Test plan
- [ ] Open `/health` on an iPhone-sized viewport
- [ ] Scroll the page vertically over the heart rate chart — page should scroll, not freeze
- [ ] Scrub horizontally on the chart — chart should respond
- [ ] Scroll the 7-day trends strip horizontally without the page jumping
- [ ] Back link is comfortable to tap