### PR TITLE
UI/UX round-3: dedupe NomNom, CTA, pill, photo, tier grid

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "static",
+      "runtimeExecutable": "python3",
+      "runtimeArgs": ["-m", "http.server", "8765"],
+      "port": 8765
+    }
+  ]
+}

--- a/css/styles.css
+++ b/css/styles.css
@@ -334,12 +334,12 @@ button:focus-visible {
 .hero__photo-wrap {
   position: relative;
   z-index: 1;
-  margin: -0.6em 0;
+  margin: -0.25em 0;
   will-change: transform, opacity;
 }
 
 .hero__photo {
-  width: min(420px, 50vw);
+  width: min(340px, 42vw);
   height: auto;
   aspect-ratio: 3 / 4;
   object-fit: cover;
@@ -730,16 +730,52 @@ button:focus-visible {
 }
 
 .proj-card--compact {
-  padding: 2rem 0;
+  padding: 1.25rem 0;
+  border-bottom: none;
 }
 
 .proj-card--compact .proj-card__title {
-  font-size: 1.25rem;
-  margin-bottom: 0.5rem;
+  font-size: 1.05rem;
+  font-weight: 700;
+  margin-bottom: 0.3rem;
 }
 
 .proj-card--compact .proj-card__desc {
-  margin-bottom: 0.75rem;
+  font-size: 0.85rem;
+  margin-bottom: 0.5rem;
+  color: var(--color-muted);
+}
+
+.proj-card--compact .proj-card__tech {
+  margin-bottom: 0.4rem;
+}
+
+.proj-card--compact .proj-card__tech span {
+  font-size: 0.7rem;
+  padding: 0.2rem 0.5rem;
+}
+
+/* Also-built grid: 2-col on desktop so cards feel like a list */
+.projects__also-built-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0;
+  border-top: 1px solid rgba(26, 26, 26, 0.08);
+  margin-top: 0;
+}
+
+.projects__also-built-grid .proj-card--compact {
+  border-right: 1px solid rgba(26, 26, 26, 0.08);
+  padding: 1.25rem 1rem 1.25rem 0;
+}
+
+.projects__also-built-grid .proj-card--compact:nth-child(even) {
+  border-right: none;
+  padding-left: 1rem;
+}
+
+.projects__also-built-grid .proj-card--compact:nth-last-child(-n + 2) {
+  border-bottom: none;
 }
 
 .gsap-ready .proj-card {
@@ -1062,18 +1098,55 @@ button:focus-visible {
 }
 
 .contact__status {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.15rem;
+  font-family: var(--font-display);
+  color: var(--color-white);
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  border-radius: 999px;
+  padding: 0.65rem 1.4rem;
+  margin-bottom: 2rem;
+  line-height: 1.3;
+}
+
+.contact__status-line {
+  display: block;
+  font-size: 0.85rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  text-transform: none;
+  opacity: 0.92;
+}
+
+.contact__status-line--primary {
+  font-weight: 700;
+  opacity: 1;
+}
+
+.contact__cta {
   display: inline-block;
   font-family: var(--font-display);
-  font-size: 0.75rem;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--color-white);
-  background: rgba(255, 255, 255, 0.15);
-  border: 1px solid rgba(255, 255, 255, 0.3);
+  font-weight: 700;
+  font-size: clamp(0.95rem, 1.4vw, 1.05rem);
+  letter-spacing: 0.02em;
+  color: var(--color-accent);
+  background: var(--color-white);
+  text-decoration: none;
+  padding: 0.85rem 1.6rem;
   border-radius: 999px;
-  padding: 0.5rem 1.1rem;
-  margin-bottom: 2rem;
+  margin-bottom: 1.5rem;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.18);
+}
+
+.contact__cta:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.22);
 }
 
 .contact__tagline {
@@ -1363,6 +1436,19 @@ button:focus-visible {
     -webkit-tap-highlight-color: transparent;
   }
 
+  .projects__also-built-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .projects__also-built-grid .proj-card--compact {
+    border-right: none;
+    padding-left: 0;
+  }
+
+  .projects__also-built-grid .proj-card--compact:nth-child(even) {
+    padding-left: 0;
+  }
+
   .scene--skills {
     padding-left: calc(1.5rem + env(safe-area-inset-left, 0px));
     padding-right: calc(1.5rem + env(safe-area-inset-right, 0px));
@@ -1414,6 +1500,20 @@ button:focus-visible {
 
   .contact__social-link:active {
     background: rgba(255, 255, 255, 0.12);
+  }
+
+  .contact__status {
+    padding: 0.55rem 1.1rem;
+    max-width: 92%;
+  }
+
+  .contact__status-line {
+    font-size: 0.78rem;
+  }
+
+  .contact__cta {
+    padding: 0.75rem 1.3rem;
+    font-size: 0.95rem;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -288,35 +288,15 @@
       <!-- ============================================ -->
       <section id="experience" class="scene scene--experience">
         <div class="experience__header">
-          <p class="section-kicker section-kicker--light">Current focus</p>
-          <h2 class="experience__heading">Experience & Projects</h2>
+          <p class="section-kicker section-kicker--light">Where I've shipped</p>
+          <h2 class="experience__heading">Experience</h2>
           <p class="section-intro section-intro--light">
-            Projects I'm building, followed by the teams where I've shipped production software and learned fast.
+            Teams and companies where I've shipped production software and learned fast.
           </p>
         </div>
         <div class="experience__track-wrapper">
           <div class="experience__track">
-            <!-- Card 1: NomNom -->
-            <article class="exp-card">
-              <span class="exp-card__date">Sep 2025 – Present</span>
-              <h3 class="exp-card__company">NomNom</h3>
-              <h4 class="exp-card__role">Building the Student and Rider apps</h4>
-              <p class="exp-card__location">San Diego, CA</p>
-              <ul class="exp-card__bullets">
-                <li>
-                  Built two React Native apps: Student app for ordering UCSD dining hall deliveries and Rider app for
-                  student couriers, using TypeScript, Firebase, and Stripe; implemented UCSD-only login and live
-                  tracking.
-                </li>
-                <li>
-                  Designed end-to-end order flow and Firestore transaction logic for OTP and drop-off delivery,
-                  preventing duplicate accepts.
-                </li>
-                <li>Integrated notifications, in-app chat, and live ETAs using Expo Location and React Native Maps.</li>
-              </ul>
-            </article>
-
-            <!-- Card 2: AWS Hyperplane -->
+            <!-- Card: AWS Hyperplane -->
             <article class="exp-card">
               <span class="exp-card__date">Jun 2025 – Sep 2025</span>
               <h3 class="exp-card__company">Amazon Web Services</h3>
@@ -339,7 +319,7 @@
               </ul>
             </article>
 
-            <!-- Card 3: TSE David Brower Center -->
+            <!-- Card: TSE David Brower Center -->
             <article class="exp-card">
               <span class="exp-card__date">Nov 2024 – Present</span>
               <h3 class="exp-card__company">Triton Software Engineering</h3>
@@ -361,7 +341,7 @@
               </ul>
             </article>
 
-            <!-- Card 4: ShareAllBooks -->
+            <!-- Card: ShareAllBooks -->
             <article class="exp-card">
               <span class="exp-card__date">Aug 2023 – Sep 2024</span>
               <h3 class="exp-card__company">ShareAllBooks</h3>
@@ -449,7 +429,9 @@
             <!-- 1. NomNom -->
             <article class="proj-card proj-card--featured" data-project="0">
               <h3 class="proj-card__title">NomNom</h3>
-              <p class="proj-card__metric">UCSD dining-hall delivery · Founder · Student + Rider apps in beta</p>
+              <p class="proj-card__metric">
+                Founder · Student + Rider apps in closed beta · Targeting ~40k UCSD students · Sep 2025 – present
+              </p>
               <p class="proj-card__desc">
                 Two-sided mobile marketplace: students order dining-hall meals, verified UCSD couriers deliver. Solves
                 the "I missed dinner" problem for the ~40k students on campus.
@@ -473,7 +455,9 @@
             <!-- 2. Outfitr -->
             <article class="proj-card proj-card--featured" data-project="1">
               <h3 class="proj-card__title">Outfitr</h3>
-              <p class="proj-card__metric">AI outfit discovery · Founder · iOS in private beta</p>
+              <p class="proj-card__metric">
+                Founder · iOS TestFlight private beta · Multi-retailer catalog ingestion · AI virtual try-on
+              </p>
               <p class="proj-card__desc">
                 Swipe-based mobile app that builds shoppable outfits across retailers. Replaces the
                 one-product-at-a-time feed with "here is the full look, buy it in one tap."
@@ -524,7 +508,9 @@
             <!-- 4. NyaayWatch -->
             <article class="proj-card" data-project="2">
               <h3 class="proj-card__title">NyaayWatch</h3>
-              <p class="proj-card__metric">Judicial observability · Public-interest · Multi-state coverage</p>
+              <p class="proj-card__metric">
+                Public-interest · Indian high-court coverage · District-level scorecards · Reproducible data pipeline
+              </p>
               <p class="proj-card__desc">
                 Turns published Indian court-system snapshots into district-level scorecards, evidence pages, and public
                 data exports — backed by a reproducible pipeline with operator-controlled publish, replay, and rollback.
@@ -536,6 +522,64 @@
                 >Visit nyaaywatch.in →</a
               >
             </article>
+
+            <p class="projects__tier-label">Also built</p>
+
+            <div class="projects__also-built-grid">
+              <!-- 5. Vibe Tracker -->
+              <article class="proj-card proj-card--compact" data-project="4">
+                <h3 class="proj-card__title">Vibe Tracker</h3>
+                <p class="proj-card__desc">
+                  GitHub commit analytics — dedup'd SHA tracking, branch/PR activity, OAuth.
+                </p>
+                <div class="proj-card__tech"><span>Next.js</span><span>TypeScript</span><span>Prisma</span></div>
+                <a
+                  href="https://vibe-tracker-max.vercel.app/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="proj-card__link"
+                  >Live →</a
+                >
+              </article>
+
+              <!-- 6. David Brower Center -->
+              <article class="proj-card proj-card--compact" data-project="5">
+                <h3 class="proj-card__title">David Brower Center</h3>
+                <p class="proj-card__desc">Nonprofit relationship-mapping platform with Triton Software Engineering.</p>
+                <div class="proj-card__tech"><span>TypeScript</span><span>React</span><span>Postgres</span></div>
+                <a
+                  href="https://github.com/TritonSE/David-Brower-Center"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="proj-card__link"
+                  >GitHub →</a
+                >
+              </article>
+
+              <!-- 7. Psyches of Color -->
+              <article class="proj-card proj-card--compact" data-project="6">
+                <h3 class="proj-card__title">Psyches of Color</h3>
+                <p class="proj-card__desc">Mental-health mobile app for underserved communities, 12-person TSE team.</p>
+                <div class="proj-card__tech"><span>React Native</span><span>Node.js</span><span>MongoDB</span></div>
+                <a
+                  href="https://github.com/TritonSE/Psyches-Of-Color-App"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="proj-card__link"
+                  >GitHub →</a
+                >
+              </article>
+
+              <!-- 8. Health Dashboard -->
+              <article class="proj-card proj-card--compact" data-project="7">
+                <h3 class="proj-card__title">Health Metrics Dashboard</h3>
+                <p class="proj-card__desc">
+                  Personal Oura Ring data pipeline — GitHub Actions, trend charts, daily status.
+                </p>
+                <div class="proj-card__tech"><span>JavaScript</span><span>Oura API</span><span>Chart.js</span></div>
+                <a href="/health/" class="proj-card__link">Dashboard →</a>
+              </article>
+            </div>
           </div>
         </div>
       </section>
@@ -566,9 +610,17 @@
       <section id="contact" class="scene scene--contact">
         <div class="contact__inner">
           <p class="contact__status">
-            Returning to AWS Hyperplane, Summer 2026 · Open to product conversations about NomNom and Outfitr
+            <span class="contact__status-line contact__status-line--primary"
+              >Returning to AWS Hyperplane · Summer 2026</span
+            >
+            <span class="contact__status-line">Open to product conversations about NomNom and Outfitr</span>
           </p>
           <p class="contact__tagline">Let's build something</p>
+          <a
+            href="mailto:rubhandari@ucsd.edu?subject=Quick%2020-minute%20chat&body=Hi%20Rudraksh%2C%20I%27d%20like%20to%20book%20a%2020-minute%20call%20about..."
+            class="contact__cta"
+            >Book a 20-minute chat →</a
+          >
           <a href="mailto:rubhandari@ucsd.edu" class="contact__email">rubhandari@ucsd.edu</a>
           <div class="contact__socials">
             <a


### PR DESCRIPTION
## Summary

Round-3 of the recruiter/incubator UI improvements. PR #332 landed the positioning rework; this adds the remaining polish layer.

- **Deduped NomNom**: removed from Experience section (was showing in both Experience and Projects); first exp card is now AWS Hyperplane
- **Founder metrics**: NomNom → "closed beta · targeting ~40k UCSD students · Sep 2025–present"; Outfitr → "TestFlight private beta · multi-retailer catalog ingestion · AI virtual try-on"; NyaayWatch → "Indian high-court coverage · district-level scorecards"
- **Contact pill split**: two lines (bold primary + lighter sub) instead of one 5-line all-caps blob on mobile
- **Book 20-min CTA**: white pill button above the email with prefilled mailto
- **Hero photo shrunk**: 420px → 340px, margin −0.6em → −0.25em so "Bhandari" clears the portrait on desktop
- **Also-built grid**: 2-col on desktop with divider rules, collapses to 1-col on mobile; compact cards feel like a list not equals

## Test plan
- [ ] Hero desktop: "Bhandari" fully visible below photo with no occlusion
- [ ] Projects: Building now / Prior work / Also built tier labels present; Also built shows 2-col grid
- [ ] Contact: pill shows two lines; "Book a 20-minute chat" button above email
- [ ] Experience: first card is AWS (not NomNom)
- [ ] Mobile: all above readable; pill and CTA not oversized