### PR TITLE
fix: compact cards full opacity; spell out SDE Intern title

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -782,6 +782,11 @@ button:focus-visible {
   opacity: 0.3;
 }
 
+/* Compact "Also built" cards are not part of the crossfade — always full opacity */
+.gsap-ready .proj-card--compact {
+  opacity: 1;
+}
+
 .proj-card.active {
   opacity: 1;
 }

--- a/index.html
+++ b/index.html
@@ -211,9 +211,10 @@
             </p>
 
             <p class="about__paragraph">
-              Last summer, I interned on the AWS Hyperplane team, and I'll be returning this coming summer. I shipped
-              internal frontend and backend tools adopted across the team, including a CLI command generator that
-              reduced on&#8209;call manual effort by ~75% and accelerated incident response.
+              Last summer, I was a Software Development Engineer (SDE) Intern on the AWS Hyperplane team, and I'll be
+              returning this coming summer. I shipped internal frontend and backend tools adopted across the team,
+              including a CLI command generator that reduced on&#8209;call manual effort by ~75% and accelerated
+              incident response.
             </p>
 
             <p class="about__paragraph">
@@ -300,7 +301,7 @@
             <article class="exp-card">
               <span class="exp-card__date">Jun 2025 – Sep 2025</span>
               <h3 class="exp-card__company">Amazon Web Services</h3>
-              <h4 class="exp-card__role">SDE Intern · Hyperplane Team</h4>
+              <h4 class="exp-card__role">Software Development Engineer (SDE) Intern · Hyperplane Team</h4>
               <p class="exp-card__location">Sunnyvale, CA</p>
               <ul class="exp-card__bullets">
                 <li>


### PR DESCRIPTION
## Fixes

**Also built cards fading out**: `.proj-card--compact` elements were inheriting the GSAP dim rule (`.gsap-ready .proj-card { opacity: 0.3 }`) but never getting activated by the crossfade highlighter, so they rendered faded on desktop. Added `.gsap-ready .proj-card--compact { opacity: 1 }` to exempt them.

**"SDE Intern" not spelled out**: About paragraph and Experience card both now say "Software Development Engineer (SDE) Intern" instead of just "interned" / "SDE Intern".