### PR TITLE
feat: co-founder exp cards, Calendly CTA, correct Outfitr date

### DIFF
--- a/index.html
+++ b/index.html
@@ -292,11 +292,47 @@
           <p class="section-kicker section-kicker--light">Where I've shipped</p>
           <h2 class="experience__heading">Experience</h2>
           <p class="section-intro section-intro--light">
-            Teams and companies where I've shipped production software and learned fast.
+            Currently co-founding two products. Previously shipped production software at AWS and nonprofits.
           </p>
         </div>
         <div class="experience__track-wrapper">
           <div class="experience__track">
+            <!-- Card: NomNom -->
+            <article class="exp-card">
+              <span class="exp-card__date">Sep 2025 – Present</span>
+              <h3 class="exp-card__company">NomNom</h3>
+              <h4 class="exp-card__role">Co-founder</h4>
+              <p class="exp-card__location">San Diego, CA</p>
+              <ul class="exp-card__bullets">
+                <li>
+                  Building a two-sided dining-hall delivery marketplace for UCSD's ~40k students — separate React Native
+                  apps for students and riders, with Stripe payments, live order tracking, and UCSD-only SSO.
+                </li>
+                <li>
+                  Shipping the Student and Rider apps in closed beta; handling product, engineering, and operations
+                  end-to-end alongside my co-founder.
+                </li>
+              </ul>
+            </article>
+
+            <!-- Card: Outfitr -->
+            <article class="exp-card">
+              <span class="exp-card__date">Feb 2026 – Present</span>
+              <h3 class="exp-card__company">Outfitr</h3>
+              <h4 class="exp-card__role">Co-founder</h4>
+              <p class="exp-card__location">Remote</p>
+              <ul class="exp-card__bullets">
+                <li>
+                  Building a swipe-based AI outfit discovery app that assembles shoppable looks across retailers —
+                  replacing the one-product feed with "here is the full look, buy it in one tap."
+                </li>
+                <li>
+                  Architecting a TypeScript monorepo across mobile app, catalog ingestion workers, AI virtual try-on
+                  pipeline, and an experimentation layer for personalisation. iOS in TestFlight private beta.
+                </li>
+              </ul>
+            </article>
+
             <!-- Card: AWS Hyperplane -->
             <article class="exp-card">
               <span class="exp-card__date">Jun 2025 – Sep 2025</span>
@@ -431,7 +467,7 @@
             <article class="proj-card proj-card--featured" data-project="0">
               <h3 class="proj-card__title">NomNom</h3>
               <p class="proj-card__metric">
-                Founder · Student + Rider apps in closed beta · Targeting ~40k UCSD students · Sep 2025 – present
+                Co-founder · Student + Rider apps in closed beta · Targeting ~40k UCSD students · Sep 2025 – present
               </p>
               <p class="proj-card__desc">
                 Two-sided mobile marketplace: students order dining-hall meals, verified UCSD couriers deliver. Solves
@@ -457,7 +493,7 @@
             <article class="proj-card proj-card--featured" data-project="1">
               <h3 class="proj-card__title">Outfitr</h3>
               <p class="proj-card__metric">
-                Founder · iOS TestFlight private beta · Multi-retailer catalog ingestion · AI virtual try-on
+                Co-founder · iOS TestFlight private beta · Multi-retailer catalog ingestion · AI virtual try-on
               </p>
               <p class="proj-card__desc">
                 Swipe-based mobile app that builds shoppable outfits across retailers. Replaces the
@@ -618,7 +654,9 @@
           </p>
           <p class="contact__tagline">Let's build something</p>
           <a
-            href="mailto:rubhandari@ucsd.edu?subject=Quick%2020-minute%20chat&body=Hi%20Rudraksh%2C%20I%27d%20like%20to%20book%20a%2020-minute%20call%20about..."
+            href="https://calendly.com/rudrakshbhandari99/20min"
+            target="_blank"
+            rel="noopener noreferrer"
             class="contact__cta"
             >Book a 20-minute chat →</a
           >


### PR DESCRIPTION
- NomNom (Sep 2025–Present) and Outfitr (Feb 2026–Present) added as co-founder experience cards
- Experience intro updated to reflect current status
- "Founder" → "Co-founder" in project metric lines
- "Book a 20-minute chat" button now links to Calendly