### PR TITLE
fix(ui): polish round 4 — text, heading, GSAP also-built

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -379,12 +379,12 @@ button:focus-visible {
 }
 
 .hero__subtitle-line:not(.hero__subtitle-line--lede) {
-  color: var(--color-muted);
+  color: rgba(26, 26, 26, 0.6);
   font-weight: 500;
   letter-spacing: 0.06em;
   font-style: italic;
   font-family: var(--font-body);
-  opacity: 0.85;
+  opacity: 1;
 }
 
 /* =============================================
@@ -743,7 +743,7 @@ button:focus-visible {
 .proj-card--compact .proj-card__desc {
   font-size: 0.85rem;
   margin-bottom: 0.5rem;
-  color: var(--color-muted);
+  color: rgba(26, 26, 26, 0.65);
 }
 
 .proj-card--compact .proj-card__tech {
@@ -861,7 +861,7 @@ button:focus-visible {
 .proj-card__desc {
   font-size: 0.95rem;
   line-height: 1.7;
-  color: var(--color-muted);
+  color: rgba(26, 26, 26, 0.65);
   margin-bottom: 1.25rem;
 }
 

--- a/index.html
+++ b/index.html
@@ -455,7 +455,7 @@
           <div class="projects__cards">
             <div class="projects__intro">
               <p class="section-kicker">Selected work</p>
-              <h2 class="projects__heading">Current projects with real users and systems</h2>
+              <h2 class="projects__heading">What I'm building</h2>
               <div class="projects__meta-links">
                 <a href="/work/" class="projects__meta-link">View all work →</a>
               </div>
@@ -652,7 +652,7 @@
             >
             <span class="contact__status-line">Open to product conversations about NomNom and Outfitr</span>
           </p>
-          <p class="contact__tagline">Let's build something</p>
+          <p class="contact__tagline">Let's build something people want</p>
           <a
             href="https://calendly.com/rudrakshbhandari99/20min"
             target="_blank"

--- a/js/animations.js
+++ b/js/animations.js
@@ -221,7 +221,9 @@ function initExperienceScene() {
 function initProjectsScene() {
   var section = document.querySelector('.scene--projects');
   var images = document.querySelectorAll('.projects__img');
-  var cards = document.querySelectorAll('.proj-card');
+  // Compact "Also built" cards are always full-opacity; exclude them from
+  // the GSAP crossfade so all four stay visible and don't compete for focus.
+  var cards = document.querySelectorAll('.proj-card:not(.proj-card--compact)');
 
   if (!section || !images.length || !cards.length) return;
 

--- a/js/main.js
+++ b/js/main.js
@@ -228,7 +228,8 @@ function animateCounter(element) {
    =========================== */
 function initProjectImageCrossfade() {
   var images = document.querySelectorAll('.projects__img');
-  var cards = document.querySelectorAll('.proj-card');
+  // Exclude compact cards — they're always full-opacity, not image-linked.
+  var cards = document.querySelectorAll('.proj-card:not(.proj-card--compact)');
 
   if (!images.length || !cards.length) return;
 


### PR DESCRIPTION
## Changes

- **Projects heading**: "Current projects with real users and systems" → **"What I'm building"** (too verbose per user feedback)
- **Contact tagline**: "Let's build something" → **"Let's build something people want"**
- **Body text contrast**: `proj-card__desc` color lifted from `--color-muted` (#8b8680) to `rgba(26,26,26,0.65)` — noticeably darker without losing hierarchy
- **Hero italic tagline**: subtitle non-lede line changed from `--color-muted` at 0.85 opacity to `rgba(26,26,26,0.60)` at full opacity — more readable
- **GSAP "Also built" fix**: changed `querySelectorAll('.proj-card')` → `'.proj-card:not(.proj-card--compact)'` in both `animations.js` and `main.js`; compact cards were competing for GSAP focus (only 2 of 4 ever activated); now all four stay at full opacity as CSS already guarantees

## Test plan
- [ ] Scroll to projects section — all 4 "Also built" cards visible at full opacity throughout
- [ ] NomNom/Outfitr/NyaayWatch/ShareAllBooks crossfade works as before
- [ ] Hero tagline italic line is noticeably more legible
- [ ] Project card descriptions are darker/easier to read
- [ ] Projects heading reads "What I'm building"
- [ ] Contact section reads "Let's build something people want"