### PR TITLE
Mention AWS backend project in About section

### DIFF
--- a/index.html
+++ b/index.html
@@ -213,8 +213,8 @@
             <p class="about__paragraph">
               Last summer, I was a Software Development Engineer (SDE) Intern on the AWS Hyperplane team, and I'll be
               returning this coming summer. I shipped internal frontend and backend tools adopted across the team,
-              including a CLI command generator that reduced on&#8209;call manual effort by ~75% and accelerated
-              incident response.
+              spanning a CLI command generator that reduced on&#8209;call manual effort by ~75% and a Java/Python AWS
+              event service for patch visibility across 14 EC2 cluster groups.
             </p>
 
             <p class="about__paragraph">


### PR DESCRIPTION
## Summary

- Adds the AWS backend event service to the About section internship paragraph.
- Keeps the existing frontend/on-call CLI project mention intact.

## Validation

```
npm run ci:check
```
