### PR TITLE
fix(ui): solid text contrast + fade left panel during also-built

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -379,7 +379,7 @@ button:focus-visible {
 }
 
 .hero__subtitle-line:not(.hero__subtitle-line--lede) {
-  color: rgba(26, 26, 26, 0.6);
+  color: #5a5653;
   font-weight: 500;
   letter-spacing: 0.06em;
   font-style: italic;
@@ -644,6 +644,12 @@ button:focus-visible {
   justify-content: center;
   overflow: hidden;
   padding: 2rem;
+  transition: opacity 0.5s ease;
+}
+
+/* Fade the image panel when "Also built" compact cards are in view */
+.scene--projects.in-also-built .projects__images {
+  opacity: 0;
 }
 
 .projects__img {
@@ -743,7 +749,7 @@ button:focus-visible {
 .proj-card--compact .proj-card__desc {
   font-size: 0.85rem;
   margin-bottom: 0.5rem;
-  color: rgba(26, 26, 26, 0.65);
+  color: #4a4845;
 }
 
 .proj-card--compact .proj-card__tech {
@@ -861,7 +867,7 @@ button:focus-visible {
 .proj-card__desc {
   font-size: 0.95rem;
   line-height: 1.7;
-  color: rgba(26, 26, 26, 0.65);
+  color: #4a4845;
   margin-bottom: 1.25rem;
 }
 

--- a/js/animations.js
+++ b/js/animations.js
@@ -269,6 +269,21 @@ function initProjectsScene() {
       activateProject(cards[0], images, cards);
     },
   });
+
+  // Fade the left image panel when the "Also built" grid scrolls into view —
+  // those cards have no paired images so the panel would otherwise look orphaned.
+  var alsoBuiltGrid = document.querySelector('.projects__also-built-grid');
+  if (alsoBuiltGrid) {
+    var alsoBuiltObserver = new IntersectionObserver(
+      function (entries) {
+        entries.forEach(function (entry) {
+          section.classList.toggle('in-also-built', entry.isIntersecting);
+        });
+      },
+      { threshold: 0.15 }
+    );
+    alsoBuiltObserver.observe(alsoBuiltGrid);
+  }
 }
 
 function activateProject(card, images, cards) {


### PR DESCRIPTION
## Changes

### Text contrast (for real this time)
Previous `rgba(26,26,26,0.65)` on a cream background was still too washed out. Switched to solid color values that don't play games with alpha blending:
- `.proj-card__desc` (all tiers): → `#4a4845`
- `.hero__subtitle-line` (italic tagline): → `#5a5653`

### Left image panel fade during "Also built"
When the user scrolls to the 4 compact cards, the left sticky image panel had no paired image — NyaayWatch just lingered there awkwardly. Fix:
- Added `transition: opacity 0.5s ease` to `.projects__images`
- Added `.scene--projects.in-also-built .projects__images { opacity: 0 }` CSS rule
- `initProjectsScene()` now attaches an `IntersectionObserver` to `.projects__also-built-grid` that toggles `.in-also-built` on the section when the grid enters/exits the viewport (threshold 15%)