### PR TITLE
fix(projects): also-built collage + correct trigger + pill copy

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -647,9 +647,45 @@ button:focus-visible {
   transition: opacity 0.5s ease;
 }
 
-/* Fade the image panel when "Also built" compact cards are in view */
-.scene--projects.in-also-built .projects__images {
+/* "Also built" collage — shown in the left panel instead of a project image */
+.projects__also-built-collage {
+  position: absolute;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+  width: 80%;
   opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.5s ease;
+}
+
+.scene--projects.in-also-built .projects__img.active {
+  opacity: 0;
+}
+
+.scene--projects.in-also-built .projects__also-built-collage {
+  opacity: 1;
+}
+
+.collage-card {
+  background: rgba(26, 26, 26, 0.04);
+  border: 1px solid rgba(26, 26, 26, 0.1);
+  border-radius: 10px;
+  padding: 1.1rem 1rem;
+}
+
+.collage-card__name {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 0.85rem;
+  color: var(--color-text);
+  margin-bottom: 0.3rem;
+}
+
+.collage-card__stack {
+  font-size: 0.72rem;
+  color: var(--color-muted);
+  letter-spacing: 0.02em;
 }
 
 .projects__img {

--- a/index.html
+++ b/index.html
@@ -449,6 +449,25 @@
               loading="lazy"
               decoding="async"
             />
+            <!-- Shown instead of a project image when "Also built" is active -->
+            <div class="projects__also-built-collage">
+              <div class="collage-card">
+                <p class="collage-card__name">Vibe Tracker</p>
+                <p class="collage-card__stack">Next.js · Prisma</p>
+              </div>
+              <div class="collage-card">
+                <p class="collage-card__name">David Brower Center</p>
+                <p class="collage-card__stack">React · Postgres</p>
+              </div>
+              <div class="collage-card">
+                <p class="collage-card__name">Psyches of Color</p>
+                <p class="collage-card__stack">React Native · MongoDB</p>
+              </div>
+              <div class="collage-card">
+                <p class="collage-card__name">Health Dashboard</p>
+                <p class="collage-card__stack">JS · Oura API</p>
+              </div>
+            </div>
           </div>
 
           <!-- Project info cards -->
@@ -650,7 +669,7 @@
             <span class="contact__status-line contact__status-line--primary"
               >Returning to AWS Hyperplane · Summer 2026</span
             >
-            <span class="contact__status-line">Open to conversations — NomNom, Outfitr, or what's next</span>
+            <span class="contact__status-line">Open to full-time roles from April 2027</span>
           </p>
           <p class="contact__tagline">Let's build something people want</p>
           <a

--- a/js/animations.js
+++ b/js/animations.js
@@ -270,19 +270,23 @@ function initProjectsScene() {
     },
   });
 
-  // Fade the left image panel when the "Also built" grid scrolls into view —
-  // those cards have no paired images so the panel would otherwise look orphaned.
-  var alsoBuiltGrid = document.querySelector('.projects__also-built-grid');
-  if (alsoBuiltGrid) {
-    var alsoBuiltObserver = new IntersectionObserver(
+  // Switch to the collage when the last featured card has scrolled above the
+  // viewport (i.e. user is now in the "Also built" region). Using the last
+  // card's exit rather than the grid's entrance avoids premature triggering
+  // while NyaayWatch is still centre-screen.
+  var lastFeaturedCard = cards[cards.length - 1];
+  if (lastFeaturedCard) {
+    var collageObserver = new IntersectionObserver(
       function (entries) {
         entries.forEach(function (entry) {
-          section.classList.toggle('in-also-built', entry.isIntersecting);
+          // true = card has scrolled above viewport (top < 0 and not intersecting)
+          var scrolledPast = !entry.isIntersecting && entry.boundingClientRect.top < 0;
+          section.classList.toggle('in-also-built', scrolledPast);
         });
       },
-      { threshold: 0.15 }
+      { threshold: 0 }
     );
-    alsoBuiltObserver.observe(alsoBuiltGrid);
+    collageObserver.observe(lastFeaturedCard);
   }
 }
 


### PR DESCRIPTION
## Changes

### Also built collage
Added a `projects__also-built-collage` 2×2 grid inside `.projects__images`. When the user scrolls into the "Also built" region, the active project image crossfades out and the collage fades in — showing all four compact project names + stacks as card tiles. Fades back to the last image on scroll back.

### Fixed trigger timing
Previous: `IntersectionObserver` on the also-built grid at `threshold: 0.15` — triggered while NyaayWatch was still centre-screen because 15% of the grid was already visible.

New: observes the last featured card (NyaayWatch) and activates `.in-also-built` only when that card's `boundingClientRect.top < 0` (scrolled fully above viewport). Precise, no premature fade.

### Contact pill line 2
`"Open to conversations — NomNom, Outfitr, or what's next"` → `"Open to full-time roles from April 2027"`