### PR TITLE
fix(about): improve paragraph transitions in about section

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,8 +249,8 @@
               Through
               <a href="https://tritonse.github.io/" target="_blank" rel="noopener noreferrer" class="text-link"
                 >Triton Software Engineering</a
-              >, I build full-stack features for the David Brower Center using TypeScript, React, Node.js, Prisma, and Postgres, which keeps me sharp
-              in team environments as well as independent builds.
+              >, I build full-stack features for the David Brower Center using TypeScript, React, Node.js, Prisma, and
+              Postgres, which keeps me sharp in team environments as well as independent builds.
             </p>
 
             <div class="about__stats">

--- a/index.html
+++ b/index.html
@@ -226,7 +226,7 @@
             </p>
 
             <p class="about__paragraph">
-              Outside of current projects, I like work that has to stand up in the real world:
+              I also build for public impact:
               <a href="https://nyaaywatch.in" target="_blank" rel="noopener noreferrer" class="text-link">NyaayWatch</a>
               turns Indian court-system snapshots into public evidence surfaces, and
               <a href="https://shareallbooks.com/" target="_blank" rel="noopener noreferrer" class="text-link"
@@ -246,11 +246,10 @@
             </p>
 
             <p class="about__paragraph">
-              I also build full-stack features with
+              Through
               <a href="https://tritonse.github.io/" target="_blank" rel="noopener noreferrer" class="text-link"
                 >Triton Software Engineering</a
-              >
-              for the David Brower Center using TypeScript, React, Node.js, Prisma, and Postgres, which keeps me sharp
+              >, I build full-stack features for the David Brower Center using TypeScript, React, Node.js, Prisma, and Postgres, which keeps me sharp
               in team environments as well as independent builds.
             </p>
 


### PR DESCRIPTION
## Summary
- Replace awkward \"Outside of current projects, I like work that has to stand up in the real world:\" with \"I also build for public impact:\" — more accurate (NyaayWatch is current) and captures the shared theme of NyaayWatch and SAB
- Rewrite \"I also build full-stack features with Triton Software Engineering\" → \"Through Triton Software Engineering, I build full-stack features\" to avoid the repetitive \"I also\" back-to-back

## Test plan
- [ ] Check about section reads naturally in sequence