### PR TITLE
fix(nav): mobile drawer was clipped to navbar height

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -125,19 +125,33 @@ button:focus-visible {
   right: 0;
   z-index: 1000;
   padding-top: env(safe-area-inset-top, 0px);
+  border-bottom: 1px solid rgba(26, 26, 26, 0.06);
+  isolation: isolate;
+}
+
+/* Backdrop on a pseudo-element so .navbar does NOT become the containing
+   block for its position:fixed mobile drawer (backdrop-filter on the
+   element itself promotes it to a containing block per CSS spec). */
+.navbar::before {
+  content: '';
+  position: absolute;
+  inset: 0;
   background: rgba(245, 240, 235, 0.85);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
-  border-bottom: 1px solid rgba(26, 26, 26, 0.06);
   transition: background 0.3s var(--ease-smooth);
+  z-index: -1;
 }
 
-.navbar.scrolled {
+.navbar.scrolled::before {
   background: rgba(245, 240, 235, 0.96);
 }
 
-.navbar.inverted {
+.navbar.inverted::before {
   background: rgba(26, 26, 26, 0.9);
+}
+
+.navbar.inverted {
   border-bottom-color: rgba(255, 255, 255, 0.06);
 }
 


### PR DESCRIPTION
## Summary
- `backdrop-filter` on `.navbar` made it the containing block for its `position: fixed` children, so the mobile drawer's `top: 60px; bottom: 0` resolved against the 60px navbar — only one nav link was visible at a time.
- Moved the blur + tinted background onto a `::before` pseudo-element and added `isolation: isolate` to scope its `z-index: -1`.

## Test plan
- [x] Mobile (375×812): drawer opens to full height, all 7 nav links visible (HOME, ABOUT, EXPERIENCE, PROJECTS, WORK, CONTACT, RÉSUMÉ).
- [x] Navbar still has blurred translucent backdrop.
- [x] `.navbar.scrolled` and `.navbar.inverted` color states still apply.
- [x] No console errors.