### PR TITLE
fix(mobile): touch-friendly footer link, tighter cards, em-dash mojibake

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -628,7 +628,7 @@ button:focus-visible {
 }
 
 .exp-card__bullets li::before {
-  content: '—';
+  content: '\2014';
   position: absolute;
   left: 0;
   color: var(--color-accent);
@@ -886,7 +886,7 @@ button:focus-visible {
 }
 
 .proj-card__bullets li::before {
-  content: '—';
+  content: '\2014';
   position: absolute;
   left: 0;
   color: var(--color-accent);
@@ -1426,13 +1426,15 @@ button:focus-visible {
   /* Experience: vertical layout on mobile */
   .experience__track {
     flex-direction: column;
-    padding: 2rem calc(1.25rem + env(safe-area-inset-left, 0px)) 2rem calc(1.25rem + env(safe-area-inset-right, 0px));
-    gap: 1.5rem;
+    padding: 1.25rem calc(1.25rem + env(safe-area-inset-left, 0px)) 1.25rem
+      calc(1.25rem + env(safe-area-inset-right, 0px));
+    gap: 1rem;
   }
 
   .exp-card {
     flex: none;
     width: 100%;
+    padding: 1.75rem;
   }
 
   /* Projects: stack vertically on mobile */
@@ -1452,7 +1454,8 @@ button:focus-visible {
   }
 
   .projects__cards {
-    padding: 2rem calc(1.1rem + env(safe-area-inset-left, 0px)) 2rem calc(1.1rem + env(safe-area-inset-right, 0px));
+    padding: 1.25rem calc(1.1rem + env(safe-area-inset-left, 0px)) 1.25rem
+      calc(1.1rem + env(safe-area-inset-right, 0px));
   }
 
   .projects__intro {
@@ -1464,8 +1467,16 @@ button:focus-visible {
   }
 
   .proj-card {
-    padding: 2rem 0;
+    padding: 1.5rem 0;
     opacity: 1;
+  }
+
+  /* Touch-friendly footer link */
+  .footer__link {
+    display: inline-flex;
+    align-items: center;
+    min-height: 44px;
+    padding: 0 0.5rem;
   }
 
   .work-hero {

--- a/css/styles.css
+++ b/css/styles.css
@@ -125,19 +125,33 @@ button:focus-visible {
   right: 0;
   z-index: 1000;
   padding-top: env(safe-area-inset-top, 0px);
+  border-bottom: 1px solid rgba(26, 26, 26, 0.06);
+  isolation: isolate;
+}
+
+/* Backdrop on a pseudo-element so .navbar does NOT become the containing
+   block for its position:fixed mobile drawer (backdrop-filter on the
+   element itself promotes it to a containing block per CSS spec). */
+.navbar::before {
+  content: '';
+  position: absolute;
+  inset: 0;
   background: rgba(245, 240, 235, 0.85);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
-  border-bottom: 1px solid rgba(26, 26, 26, 0.06);
   transition: background 0.3s var(--ease-smooth);
+  z-index: -1;
 }
 
-.navbar.scrolled {
+.navbar.scrolled::before {
   background: rgba(245, 240, 235, 0.96);
 }
 
-.navbar.inverted {
+.navbar.inverted::before {
   background: rgba(26, 26, 26, 0.9);
+}
+
+.navbar.inverted {
   border-bottom-color: rgba(255, 255, 255, 0.06);
 }
 


### PR DESCRIPTION
## Summary
Three small mobile fixes surfaced during a UI/UX review on a 375×812 viewport.

- **Footer tap target**: "Health dashboard" was a 22px-tall link — below iOS/Material's 44px touch minimum. Padded to 44px on mobile only.
- **Experience / Projects cards**: tightened vertical padding on the track and inner cards so they feel less airy at narrow widths.
- **Em-dash mojibake in CSS**: the static dev server doesn't set a charset on `.css` and there's no `@charset` rule, so the UTF-8 em-dash in `::before { content: '—' }` rendered as `â€"` on some loads. Replaced with the encoding-safe `\2014` escape in both `.exp-card__bullets` and `.proj-card__bullets`.

> Note: based on top of #378. Once that lands the rebase will be a no-op.

## Test plan
- [x] Mobile (375×812): "Health dashboard" link is 44px tall.
- [x] Experience cards visibly less padded; bullets render as proper em-dashes.
- [x] Projects bullets render as proper em-dashes.
- [x] No console errors; no horizontal overflow.