### PR TITLE
fix(projects): correct NyaayWatch description to match README

### DIFF
--- a/index.html
+++ b/index.html
@@ -564,7 +564,8 @@
             <article class="proj-card" data-project="2">
               <h3 class="proj-card__title">NyaayWatch</h3>
               <p class="proj-card__metric">
-                Public-interest · Supreme Court, all 25 High Courts, every state & UT · NJDG-sourced · Reproducible snapshots
+                Public-interest · Supreme Court, all 25 High Courts, every state & UT · NJDG-sourced · Reproducible
+                snapshots
               </p>
               <p class="proj-card__desc">
                 Publishes reviewed, versioned snapshots of pending caseloads, clearance rates, and wait times across

--- a/index.html
+++ b/index.html
@@ -564,11 +564,12 @@
             <article class="proj-card" data-project="2">
               <h3 class="proj-card__title">NyaayWatch</h3>
               <p class="proj-card__metric">
-                Public-interest · Indian high-court coverage · District-level scorecards · Reproducible data pipeline
+                Public-interest · Supreme Court, all 25 High Courts, every state & UT · NJDG-sourced · Reproducible snapshots
               </p>
               <p class="proj-card__desc">
-                Turns published Indian court-system snapshots into district-level scorecards, evidence pages, and public
-                data exports — backed by a reproducible pipeline with operator-controlled publish, replay, and rollback.
+                Publishes reviewed, versioned snapshots of pending caseloads, clearance rates, and wait times across
+                India's Supreme Court, all 25 High Courts, and the lower courts in every state and Union Territory —
+                drawn from public NJDG data with full methodology, every number linked to a dated source.
               </p>
               <div class="proj-card__tech">
                 <span>Node.js</span><span>TypeScript</span><span>PostgreSQL</span><span>AWS</span>

--- a/work/index.html
+++ b/work/index.html
@@ -140,8 +140,8 @@
               <p>
                 Public-interest judicial observability platform publishing reviewed, versioned snapshots of pending
                 caseloads, clearance rates, and wait times across India's Supreme Court, all 25 High Courts, and lower
-                courts in every state and Union Territory — sourced from NJDG with full methodology and operator-controlled
-                publish, replay, and rollback.
+                courts in every state and Union Territory — sourced from NJDG with full methodology and
+                operator-controlled publish, replay, and rollback.
               </p>
               <div class="proj-card__tech">
                 <span>Node.js</span><span>TypeScript</span><span>PostgreSQL</span><span>AWS</span>

--- a/work/index.html
+++ b/work/index.html
@@ -138,8 +138,10 @@
               <p class="work-card__meta">Civic data · 2026</p>
               <h3>NyaayWatch</h3>
               <p>
-                Public-interest judicial observability platform turning Indian court-system snapshots into district
-                scorecards, evidence pages, exports, methodology, and reproducible publish workflows.
+                Public-interest judicial observability platform publishing reviewed, versioned snapshots of pending
+                caseloads, clearance rates, and wait times across India's Supreme Court, all 25 High Courts, and lower
+                courts in every state and Union Territory — sourced from NJDG with full methodology and operator-controlled
+                publish, replay, and rollback.
               </p>
               <div class="proj-card__tech">
                 <span>Node.js</span><span>TypeScript</span><span>PostgreSQL</span><span>AWS</span>


### PR DESCRIPTION
## Summary
- The NyaayWatch project card on the home page and the work-page card both undersold the project as "Indian high-court coverage" with "district-level scorecards" — that's narrower than what the README actually describes.
- Per the [NyaayWatch README](https://github.com/rudrakshbhandari/nyaaywatch/blob/main/README.md), the project covers the **full Indian court hierarchy**: Supreme Court + all 25 High Courts + lower courts in every state and Union Territory, drawn from public NJDG data.
- Updates both surfaces (home `index.html`, `work/index.html`) to publish accurate scope, source (NJDG), and the actual metrics: pending caseloads, clearance rates, wait times.

## Test plan
- [ ] Visual check of NyaayWatch card on home page (`/#projects`)
- [ ] Visual check of NyaayWatch entry on `/work/`
- [ ] Confirm no copy overflow on mobile widths