### PR TITLE
fix(health): harden stale dashboard watchdog

### DIFF
--- a/.github/workflows/health-dashboard-watchdog.yml
+++ b/.github/workflows/health-dashboard-watchdog.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Evaluate dashboard freshness
         id: freshness
         env:
-          OURA_MAX_STALENESS_HOURS: '36'
+          OURA_MAX_STALENESS_HOURS: '12'
         run: node scripts/check-health-dashboard-freshness.mjs
 
       - name: Open or update staleness alert
@@ -54,6 +54,12 @@ jobs:
           else
             gh issue create --title "$ISSUE_TITLE" --body-file .health_alert_body.md
           fi
+
+      - name: Fail watchdog when dashboard is stale
+        if: steps.freshness.outputs.is_stale == 'true'
+        run: |
+          echo "::error::Health dashboard data is stale: ${{ steps.freshness.outputs.age_hours }} hours old, threshold ${{ steps.freshness.outputs.max_staleness_hours }} hours."
+          exit 1
 
       - name: Close staleness alert after recovery
         if: steps.freshness.outputs.is_stale != 'true'

--- a/docs/OURA_AUTOMATION.md
+++ b/docs/OURA_AUTOMATION.md
@@ -6,6 +6,7 @@ This note exists to keep future maintenance work on the Oura health pipeline fro
 
 - `oura_public.json` is the only public payload for `/health`.
 - `.github/workflows/oura-update.yml` is the scheduled production path.
+- `.github/workflows/health-dashboard-watchdog.yml` is the hourly freshness alert path and must fail when data is more than 12 hours old.
 - `scripts/fetch_oura_and_write_json.mjs` is the single source of truth for local and CI fetch behavior.
 - CI and local runs intentionally behave differently when auth breaks.
 
@@ -30,6 +31,12 @@ The scheduled workflow opens a PR when `oura_public.json` changes. **Do not use 
 - The script allocates a fresh localhost callback port for each recovery attempt instead of assuming port `3000` is free.
 - After successful browser auth, the new refresh token is saved back to `.oura_token`.
 - CI does **not** use this fallback. In GitHub Actions, auth failures should still fail loudly so the workflow alerting remains trustworthy.
+
+## Alerting Model
+
+- The health dashboard freshness threshold is 12 hours.
+- The watchdog opens or updates the `Health dashboard automation alert` issue when data is stale.
+- After writing the issue, the watchdog fails the workflow so GitHub Actions failure notifications are a second alert path.
 
 ## Agent Rules
 

--- a/scripts/check-health-dashboard-freshness.mjs
+++ b/scripts/check-health-dashboard-freshness.mjs
@@ -9,7 +9,7 @@ import { resolve } from 'path';
 
 const DATA_PATH = resolve(process.cwd(), 'oura_public.json');
 const GITHUB_OUTPUT_PATH = process.env.GITHUB_OUTPUT;
-const MAX_STALENESS_HOURS = Number(process.env.OURA_MAX_STALENESS_HOURS || 36);
+const MAX_STALENESS_HOURS = Number(process.env.OURA_MAX_STALENESS_HOURS || 12);
 
 function setOutput(name, value) {
   if (!GITHUB_OUTPUT_PATH) {


### PR DESCRIPTION
Summary: Restores the health dashboard stale threshold to 12 hours, makes stale watchdog runs fail after updating the alert issue, and documents the alerting model. Validation: npm run check:syntax; node scripts/check-health-dashboard-freshness.mjs.