### PR TITLE
fix(oura): use registered local callback for reauth

### DIFF
--- a/docs/OURA_AUTOMATION.md
+++ b/docs/OURA_AUTOMATION.md
@@ -28,7 +28,7 @@ The scheduled workflow opens a PR when `oura_public.json` changes. **Do not use 
 ## Current Recovery Behavior
 
 - If a local refresh token is stale, `scripts/fetch_oura_and_write_json.mjs` now starts a browser OAuth recovery flow automatically.
-- The script allocates a fresh localhost callback port for each recovery attempt instead of assuming port `3000` is free.
+- The browser recovery flow uses the registered local callback `http://localhost:3000/callback` by default. Override with `OURA_OAUTH_REDIRECT_URI` or `OURA_OAUTH_CALLBACK_PORT` only if the Oura app registration changes.
 - After successful browser auth, the new refresh token is saved back to `.oura_token`.
 - CI does **not** use this fallback. In GitHub Actions, auth failures should still fail loudly so the workflow alerting remains trustworthy.
 
@@ -42,7 +42,7 @@ The scheduled workflow opens a PR when `oura_public.json` changes. **Do not use 
 
 - Do not remove the local browser reauth fallback unless the replacement is equally automatic and fully verified.
 - Do not make CI silently preserve stale data on auth failure. Production automation must fail loudly.
-- Do not hardcode a single localhost callback port for Oura OAuth.
+- Do not switch local browser reauth back to a random callback port unless the Oura app is registered for that exact redirect URI; Oura rejects unregistered callback ports before approval.
 - Do not commit `.oura_token`, `.env`, or rotated token artifacts.
 - Prefer updating `scripts/fetch_oura_and_write_json.mjs` over creating parallel auth logic in new scripts.
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -224,7 +224,8 @@ To test the GitHub Actions workflow immediately:
 
 - This usually means the local `.oura_token` is stale or revoked
 - Complete the browser OAuth flow and let the script finish updating `.oura_token`
-- Do not replace the dynamic localhost callback logic with a hardcoded port; the script intentionally uses a fresh loopback port per recovery attempt
+- The browser OAuth flow defaults to `http://localhost:3000/callback`, which must match the Oura app's registered redirect URI
+- If the Oura app registration changes, set `OURA_OAUTH_REDIRECT_URI` or `OURA_OAUTH_CALLBACK_PORT` before running the script
 - See `docs/OURA_AUTOMATION.md` before changing the auth flow
 
 ### "No data" showing on health page

--- a/scripts/fetch_oura_and_write_json.mjs
+++ b/scripts/fetch_oura_and_write_json.mjs
@@ -23,6 +23,7 @@ const IS_GITHUB_ACTIONS = process.env.GITHUB_ACTIONS === 'true';
 const SHOULD_FAIL_ON_API_ERROR = IS_GITHUB_ACTIONS || process.env.OURA_FAIL_ON_API_ERROR === 'true';
 const PT_TIME_ZONE = 'America/Los_Angeles';
 const OAUTH_SCOPES = ['daily', 'heartrate', 'spo2Daily', 'workout'];
+const DEFAULT_OAUTH_CALLBACK_PORT = 3000;
 /** Max HR samples in public JSON (~minute-level over 24h; keeps payload small vs full Oura stream). */
 const HR_TIMELINE_MAX_POINTS = 1440;
 
@@ -207,38 +208,52 @@ function createOauthState() {
 }
 
 /**
- * Reserve a free loopback port for the OAuth callback server
- * @returns {Promise<number>}
- */
-function allocateCallbackPort() {
-  return new Promise((resolve, reject) => {
-    const server = http.createServer();
-    server.listen(0, '127.0.0.1', () => {
-      const address = server.address();
-      const port = typeof address === 'object' && address ? address.port : null;
-      server.close(closeError => {
-        if (closeError) {
-          reject(closeError);
-          return;
-        }
-        if (!port) {
-          reject(new Error('Could not allocate OAuth callback port'));
-          return;
-        }
-        resolve(port);
-      });
-    });
-    server.on('error', reject);
-  });
-}
-
-/**
  * Build a loopback redirect URI from a callback port
  * @param {number} callbackPort
  * @returns {string}
  */
 function buildRedirectUri(callbackPort) {
   return `http://localhost:${callbackPort}/callback`;
+}
+
+/**
+ * Resolve the OAuth redirect URI registered with Oura for local recovery.
+ * Oura requires an exact redirect URI match, so the default is the repo's
+ * registered localhost callback instead of an arbitrary free port.
+ * @returns {{redirectUri: string, callbackPort: number}}
+ */
+function getLocalOAuthRedirectConfig() {
+  const configuredRedirectUri = (process.env.OURA_OAUTH_REDIRECT_URI || process.env.OURA_REDIRECT_URI || '').trim();
+
+  if (configuredRedirectUri) {
+    let parsed;
+    try {
+      parsed = new URL(configuredRedirectUri);
+    } catch {
+      throw new Error(`Invalid Oura OAuth redirect URI: ${configuredRedirectUri}`);
+    }
+
+    const isLoopback = parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1';
+    if (parsed.protocol !== 'http:' || !isLoopback || parsed.pathname !== '/callback') {
+      throw new Error(
+        'Oura OAuth redirect URI must be http://localhost:<port>/callback or http://127.0.0.1:<port>/callback'
+      );
+    }
+
+    const callbackPort = Number(parsed.port || DEFAULT_OAUTH_CALLBACK_PORT);
+    if (!Number.isInteger(callbackPort) || callbackPort <= 0) {
+      throw new Error(`Invalid Oura OAuth callback port in redirect URI: ${configuredRedirectUri}`);
+    }
+
+    return { redirectUri: configuredRedirectUri, callbackPort };
+  }
+
+  const callbackPort = Number(process.env.OURA_OAUTH_CALLBACK_PORT || DEFAULT_OAUTH_CALLBACK_PORT);
+  if (!Number.isInteger(callbackPort) || callbackPort <= 0) {
+    throw new Error(`Invalid OURA_OAUTH_CALLBACK_PORT: ${process.env.OURA_OAUTH_CALLBACK_PORT}`);
+  }
+
+  return { redirectUri: buildRedirectUri(callbackPort), callbackPort };
 }
 
 /**
@@ -385,8 +400,7 @@ async function exchangeAuthorizationCode(clientId, clientSecret, code, redirectU
 async function recoverCredentialsInteractively(clientId, clientSecret) {
   console.warn('Refresh token rejected. Starting one-time browser reauthorization to recover local access...');
   const state = createOauthState();
-  const callbackPort = await allocateCallbackPort();
-  const redirectUri = buildRedirectUri(callbackPort);
+  const { redirectUri, callbackPort } = getLocalOAuthRedirectConfig();
   const authUrl = buildAuthorizationUrl(clientId, state, redirectUri);
   console.log('Approve access in your browser if prompted:');
   console.log(authUrl);


### PR DESCRIPTION
Summary: Updates the local Oura browser reauth path to use the registered localhost:3000 callback by default instead of an arbitrary random port, with env overrides for future app-registration changes. Refreshes the Oura automation docs to match the working recovery path. Validation: npm run format:check; npm run check:syntax; node scripts/check-health-dashboard-freshness.mjs.