### PR TITLE
Update portfolio: Outfitr focus, technical details, NomNom context

### DIFF
--- a/index.html
+++ b/index.html
@@ -424,7 +424,7 @@
           <!-- Project images (stacked, crossfaded) -->
           <div class="projects__images" aria-hidden="true">
             <img
-              src="img/nomnom.png?v=2"
+              src="img/outfitr-live.png?v=1"
               alt=""
               class="projects__img"
               data-project="0"
@@ -432,7 +432,7 @@
               decoding="async"
             />
             <img
-              src="img/outfitr-live.png?v=1"
+              src="img/nomnom.png?v=2"
               alt=""
               class="projects__img"
               data-project="1"

--- a/index.html
+++ b/index.html
@@ -167,9 +167,9 @@
           </h1>
           <p class="hero__subtitle">
             <span class="hero__subtitle-line hero__subtitle-line--lede"
-              >ML Researcher @ UCSD · SDE Intern @ AWS (returning '26) · Building NomNom and Outfitr</span
+              >Co-founder & CTO, Outfitr · CS + ML @ UCSD</span
             >
-            <span class="hero__subtitle-line">Machine learning, mobile systems, and public-interest software</span>
+            <span class="hero__subtitle-line">Shipped my first app at 16. Building the way people discover and shop fashion.</span>
           </p>
         </div>
       </section>
@@ -218,11 +218,13 @@
             </p>
 
             <p class="about__paragraph">
-              I'm currently building
-              <a href="https://nomnom.cc" target="_blank" rel="noopener noreferrer" class="text-link">NomNom</a>, a UCSD
-              delivery product, and
-              <a href="https://outfitr.net/" target="_blank" rel="noopener noreferrer" class="text-link">Outfitr</a>, an
-              AI-native fashion discovery product across mobile, backend, and experimentation systems.
+              I'm co-founding
+              <a href="https://outfitr.net/" target="_blank" rel="noopener noreferrer" class="text-link">Outfitr</a> with
+              Yuni Kim — a swipe-first app where you discover items across retailers, Outfitr composes outfit
+              suggestions from your saves, you try them on with AI, and buy the whole look in one tap. I also co-founded
+              <a href="https://nomnom.cc" target="_blank" rel="noopener noreferrer" class="text-link">NomNom</a>, a dining-hall
+              delivery marketplace for UCSD's ~40k students, building both the student and rider apps solo before UCSD
+              admin shut us down — which taught us that products requiring institutional permission don't scale.
             </p>
 
             <p class="about__paragraph">
@@ -291,7 +293,7 @@
           <p class="section-kicker section-kicker--light">Where I've shipped</p>
           <h2 class="experience__heading">Experience</h2>
           <p class="section-intro section-intro--light">
-            Currently co-founding two products. Previously shipped production software at AWS and nonprofits.
+            Co-founding Outfitr. Building the full stack solo. Previously: AWS Hyperplane, two UCSD ML labs, NomNom.
           </p>
         </div>
         <div class="experience__track-wrapper">
@@ -322,8 +324,10 @@
               <p class="exp-card__location">Remote</p>
               <ul class="exp-card__bullets">
                 <li>
-                  Building a swipe-based AI outfit discovery app that assembles shoppable looks across retailers —
-                  discover and shop complete outfits instead of single items, one swipe at a time.
+                  Swipe individual pieces from a multi-retailer catalog. Outfitr composes outfit suggestions from what
+                  you've saved, runs AI virtual try-on on any look, routes friend feedback through a share loop, and
+                  closes with one-tap bundle checkout. I'm writing every line of code: React Native / Expo app, Fastify
+                  BFF, catalog ingestion pipeline, outfit ranking engine, VTO orchestration, and AWS infrastructure.
                 </li>
                 <li>
                   Architecting a TypeScript monorepo across mobile app, catalog ingestion workers, AI virtual try-on
@@ -488,8 +492,9 @@
                 Co-founder · Student + Rider apps in closed beta · Targeting ~40k UCSD students · Sep 2025 – present
               </p>
               <p class="proj-card__desc">
-                Two-sided mobile marketplace: students order dining-hall meals, verified UCSD couriers deliver.
-                Dining-hall food, on demand for 40k students.
+                Two-sided dining-hall delivery marketplace for UCSD's ~40k students. Built and shipped both the student
+                and rider apps solo. Shut down by UCSD administration — taught us that products requiring institutional
+                permission don't scale.
               </p>
               <ul class="proj-card__bullets">
                 <li>Built dual React Native apps (Student + Rider) in a TypeScript monorepo.</li>
@@ -511,11 +516,13 @@
             <article class="proj-card proj-card--featured" data-project="1">
               <h3 class="proj-card__title">Outfitr</h3>
               <p class="proj-card__metric">
-                Co-founder · iOS TestFlight private beta · Multi-retailer catalog ingestion · AI virtual try-on
+                Co-founder & CTO · Solo engineer, full stack · iOS TestFlight · Multi-retailer catalog · Outfit composition from saves · AI virtual try-on
               </p>
               <p class="proj-card__desc">
-                Swipe-based mobile app that builds shoppable outfits across retailers. Discover and shop complete looks
-                instead of single items — one swipe, one tap, full outfit.
+                Fashion discovery is broken across five apps. Outfitr collapses it into one swipe feed: browse
+                individual pieces curated across retailers, save what catches your eye, and Outfitr composes outfit
+                suggestions from your saves. Try any look on with AI before you commit, share with a friend for the
+                thumbs-up, and buy the whole outfit in one tap.
               </p>
               <ul class="proj-card__bullets">
                 <li>TypeScript monorepo: mobile app, API, ingestion workers, shared SDK.</li>
@@ -668,9 +675,10 @@
         <div class="contact__inner">
           <p class="contact__status">
             <span class="contact__status-line contact__status-line--primary"
-              >Looking for full-time roles from April 2027</span
+              >Full-time on Outfitr through 2026.</span
             >
-            <span class="contact__status-line">Open to conversations about NomNom &amp; Outfitr</span>
+            <span class="contact__status-line">Open to full-time SWE roles from April 2027.</span>
+            <span class="contact__status-line">Open to conversations with investors, retail partners, and early users of Outfitr.</span>
           </p>
           <p class="contact__tagline">Let's build something people want</p>
           <a

--- a/index.html
+++ b/index.html
@@ -489,7 +489,7 @@
             <p class="projects__tier-label">Building now</p>
 
             <!-- 1. Outfitr -->
-            <article class="proj-card proj-card--featured" data-project="1">
+            <article class="proj-card proj-card--featured" data-project="0">
               <h3 class="proj-card__title">Outfitr</h3>
               <p class="proj-card__metric">
                 Co-founder & CTO · Solo engineer, full stack · iOS TestFlight · Multi-retailer catalog · Outfit
@@ -521,7 +521,7 @@
             <p class="projects__tier-label">Prior work</p>
 
             <!-- 2. NomNom -->
-            <article class="proj-card" data-project="0">
+            <article class="proj-card" data-project="1">
               <h3 class="proj-card__title">NomNom</h3>
               <p class="proj-card__metric">
                 Co-founder · Student + Rider apps in closed beta · Targeting ~40k UCSD students · Sep 2025 – Mar 2026

--- a/index.html
+++ b/index.html
@@ -303,7 +303,7 @@
           <div class="experience__track">
             <!-- Card: NomNom -->
             <article class="exp-card">
-              <span class="exp-card__date">Sep 2025 – Present</span>
+              <span class="exp-card__date">Sep 2025 – Mar 2026</span>
               <h3 class="exp-card__company">NomNom</h3>
               <h4 class="exp-card__role">Co-founder</h4>
               <p class="exp-card__location">San Diego, CA</p>
@@ -492,7 +492,7 @@
             <article class="proj-card proj-card--featured" data-project="0">
               <h3 class="proj-card__title">NomNom</h3>
               <p class="proj-card__metric">
-                Co-founder · Student + Rider apps in closed beta · Targeting ~40k UCSD students · Sep 2025 – present
+                Co-founder · Student + Rider apps in closed beta · Targeting ~40k UCSD students · Sep 2025 – Mar 2026
               </p>
               <p class="proj-card__desc">
                 Two-sided dining-hall delivery marketplace for UCSD's ~40k students. Built and shipped both the student

--- a/index.html
+++ b/index.html
@@ -169,7 +169,9 @@
             <span class="hero__subtitle-line hero__subtitle-line--lede"
               >Co-founder & CTO, Outfitr · CS + ML @ UCSD</span
             >
-            <span class="hero__subtitle-line">Shipped my first app at 16. Building the way people discover and shop fashion.</span>
+            <span class="hero__subtitle-line"
+              >Shipped my first app at 16. Building the way people discover and shop fashion.</span
+            >
           </p>
         </div>
       </section>
@@ -219,12 +221,13 @@
 
             <p class="about__paragraph">
               I'm co-founding
-              <a href="https://outfitr.net/" target="_blank" rel="noopener noreferrer" class="text-link">Outfitr</a> with
-              Yuni Kim — a swipe-first app where you discover items across retailers, Outfitr composes outfit
+              <a href="https://outfitr.net/" target="_blank" rel="noopener noreferrer" class="text-link">Outfitr</a>
+              with Yuni Kim — a swipe-first app where you discover items across retailers, Outfitr composes outfit
               suggestions from your saves, you try them on with AI, and buy the whole look in one tap. I also co-founded
-              <a href="https://nomnom.cc" target="_blank" rel="noopener noreferrer" class="text-link">NomNom</a>, a dining-hall
-              delivery marketplace for UCSD's ~40k students, building both the student and rider apps solo before UCSD
-              admin shut us down — which taught us that products requiring institutional permission don't scale.
+              <a href="https://nomnom.cc" target="_blank" rel="noopener noreferrer" class="text-link">NomNom</a>, a
+              dining-hall delivery marketplace for UCSD's ~40k students, building both the student and rider apps solo
+              before UCSD admin shut us down — which taught us that products requiring institutional permission don't
+              scale.
             </p>
 
             <p class="about__paragraph">
@@ -516,7 +519,8 @@
             <article class="proj-card proj-card--featured" data-project="1">
               <h3 class="proj-card__title">Outfitr</h3>
               <p class="proj-card__metric">
-                Co-founder & CTO · Solo engineer, full stack · iOS TestFlight · Multi-retailer catalog · Outfit composition from saves · AI virtual try-on
+                Co-founder & CTO · Solo engineer, full stack · iOS TestFlight · Multi-retailer catalog · Outfit
+                composition from saves · AI virtual try-on
               </p>
               <p class="proj-card__desc">
                 Fashion discovery is broken across five apps. Outfitr collapses it into one swipe feed: browse
@@ -674,11 +678,11 @@
       <section id="contact" class="scene scene--contact">
         <div class="contact__inner">
           <p class="contact__status">
-            <span class="contact__status-line contact__status-line--primary"
-              >Full-time on Outfitr through 2026.</span
-            >
+            <span class="contact__status-line contact__status-line--primary">Full-time on Outfitr through 2026.</span>
             <span class="contact__status-line">Open to full-time SWE roles from April 2027.</span>
-            <span class="contact__status-line">Open to conversations with investors, retail partners, and early users of Outfitr.</span>
+            <span class="contact__status-line"
+              >Open to conversations with investors, retail partners, and early users of Outfitr.</span
+            >
           </p>
           <p class="contact__tagline">Let's build something people want</p>
           <a

--- a/index.html
+++ b/index.html
@@ -488,34 +488,7 @@
 
             <p class="projects__tier-label">Building now</p>
 
-            <!-- 1. NomNom -->
-            <article class="proj-card proj-card--featured" data-project="0">
-              <h3 class="proj-card__title">NomNom</h3>
-              <p class="proj-card__metric">
-                Co-founder · Student + Rider apps in closed beta · Targeting ~40k UCSD students · Sep 2025 – Mar 2026
-              </p>
-              <p class="proj-card__desc">
-                Two-sided dining-hall delivery marketplace for UCSD's ~40k students. Built and shipped both the student
-                and rider apps solo. Shut down by UCSD administration — taught us that products requiring institutional
-                permission don't scale.
-              </p>
-              <ul class="proj-card__bullets">
-                <li>Built dual React Native apps (Student + Rider) in a TypeScript monorepo.</li>
-                <li>
-                  Firestore transactions for order accept/drop-off; OTP + live tracking eliminate double-claims and
-                  disputes.
-                </li>
-                <li>Stripe payments, Expo Location ETAs, in-app chat, UCSD-only SSO.</li>
-              </ul>
-              <div class="proj-card__tech">
-                <span>React Native</span><span>TypeScript</span><span>Firestore</span><span>Stripe</span>
-              </div>
-              <a href="https://nomnom.cc" target="_blank" rel="noopener noreferrer" class="proj-card__link"
-                >Visit nomnom.cc →</a
-              >
-            </article>
-
-            <!-- 2. Outfitr -->
+            <!-- 1. Outfitr -->
             <article class="proj-card proj-card--featured" data-project="1">
               <h3 class="proj-card__title">Outfitr</h3>
               <p class="proj-card__metric">
@@ -546,6 +519,33 @@
             </article>
 
             <p class="projects__tier-label">Prior work</p>
+
+            <!-- 2. NomNom -->
+            <article class="proj-card" data-project="0">
+              <h3 class="proj-card__title">NomNom</h3>
+              <p class="proj-card__metric">
+                Co-founder · Student + Rider apps in closed beta · Targeting ~40k UCSD students · Sep 2025 – Mar 2026
+              </p>
+              <p class="proj-card__desc">
+                Two-sided dining-hall delivery marketplace for UCSD's ~40k students. Built and shipped both the student
+                and rider apps solo. Shut down by UCSD administration — taught us that products requiring institutional
+                permission don't scale.
+              </p>
+              <ul class="proj-card__bullets">
+                <li>Built dual React Native apps (Student + Rider) in a TypeScript monorepo.</li>
+                <li>
+                  Firestore transactions for order accept/drop-off; OTP + live tracking eliminate double-claims and
+                  disputes.
+                </li>
+                <li>Stripe payments, Expo Location ETAs, in-app chat, UCSD-only SSO.</li>
+              </ul>
+              <div class="proj-card__tech">
+                <span>React Native</span><span>TypeScript</span><span>Firestore</span><span>Stripe</span>
+              </div>
+              <a href="https://nomnom.cc" target="_blank" rel="noopener noreferrer" class="proj-card__link"
+                >Visit nomnom.cc →</a
+              >
+            </article>
 
             <!-- 3. ShareAllBooks -->
             <article class="proj-card" data-project="3">


### PR DESCRIPTION
## Summary
Updated 9 portfolio sections to reflect Outfitr as primary focus and co-founder role. Added technical stack details, Yuni Kim as co-founder credit, and context about NomNom shutdown.

## Changes
- Hero: Updated tagline to "Co-founder & CTO, Outfitr · CS + ML @ UCSD"
- Hero subtitle: "Shipped my first app at 16. Building the way people discover and shop fashion."
- About: Expanded Outfitr description + NomNom as past project with admin shutdown context
- Experience intro: Clarified Outfitr full-stack solo build
- Outfitr experience card: Added technical details (React Native, Fastify, VTO, AWS)
- Outfitr project card: Reframed around "Fashion discovery is broken across five apps"
- Outfitr meta: "Co-founder & CTO · Solo engineer, full stack"
- NomNom project card: Added solo build + admin shutdown context
- Contact: 3 new lines (Outfitr through 2026, April 2027 SWE roles, investor/partner/user conversations)