### PR TITLE
Clarify TSE and NyaayWatch as separate efforts

### DIFF
--- a/index.html
+++ b/index.html
@@ -231,12 +231,11 @@
             </p>
 
             <p class="about__paragraph">
-              I also build for public impact through
+              I also build for public impact. Through
               <a href="https://tritonse.github.io/" target="_blank" rel="noopener noreferrer" class="text-link"
                 >Triton Software Engineering</a
-              >, a student-led non-profit that delivers full-stack software solutions to mission-driven organizations
-              each year. I've contributed to projects across civic data, book-sharing, and health tech—helping
-              organizations scale their impact with technology. One project I'm proud of:
+              >, a student-led organization, I've contributed to pro-bono projects for nonprofits across civic data,
+              health tech, and social impact. I'm also proud of
               <a href="https://nyaaywatch.in" target="_blank" rel="noopener noreferrer" class="text-link">NyaayWatch</a
               >, an open-source platform that turns Indian court-system data into public evidence surfaces.
             </p>


### PR DESCRIPTION
Separate the TSE nonprofit work from the independent NyaayWatch project to avoid ambiguity. Correctly identifies TSE as working with nonprofits (not just mission-driven orgs).