### PR TITLE
feat(about): remove GPA stat

### DIFF
--- a/index.html
+++ b/index.html
@@ -242,10 +242,6 @@
 
             <div class="about__stats">
               <div class="about__stat">
-                <span class="about__stat-number" data-target="3.9">3.9</span>
-                <span class="about__stat-label">GPA @ UCSD</span>
-              </div>
-              <div class="about__stat">
                 <span
                   class="about__stat-number"
                   data-target="2K+"


### PR DESCRIPTION
Removes the GPA stat from the about section, leaving just App Downloads and Monthly Site Visitors. Two strong outcome metrics are cleaner than three where one is a credential.