### PR TITLE
Fix About paragraph order and ShareAllBooks role title

### DIFF
--- a/index.html
+++ b/index.html
@@ -213,13 +213,6 @@
             </p>
 
             <p class="about__paragraph">
-              Last summer, I was a Software Development Engineer (SDE) Intern on the AWS Hyperplane team, and I'll be
-              returning this coming summer. I shipped internal frontend and backend tools adopted across the team,
-              spanning a CLI command generator that reduced on&#8209;call manual effort by ~75% and a Java/Python AWS
-              event service for patch visibility across 14 EC2 cluster groups.
-            </p>
-
-            <p class="about__paragraph">
               I'm co-founding
               <a href="https://outfitr.net/" target="_blank" rel="noopener noreferrer" class="text-link">Outfitr</a>
               with Yuni Kim — wardrobe-first social fashion that plans what to wear today from clothes you already own,
@@ -229,6 +222,13 @@
               dining-hall delivery marketplace for UCSD's ~40k students, building both the student and rider apps solo
               before UCSD admin shut us down — which taught us that products requiring institutional permission don't
               scale.
+            </p>
+
+            <p class="about__paragraph">
+              Last summer, I was a Software Development Engineer (SDE) Intern on the AWS Hyperplane team, and I'll be
+              returning this coming summer. I shipped internal frontend and backend tools adopted across the team,
+              spanning a CLI command generator that reduced on&#8209;call manual effort by ~75% and a Java/Python AWS
+              event service for patch visibility across 14 EC2 cluster groups.
             </p>
 
             <p class="about__paragraph">
@@ -416,7 +416,7 @@
             <article class="exp-card">
               <span class="exp-card__date">Aug 2023 – Sep 2024</span>
               <h3 class="exp-card__company">ShareAllBooks</h3>
-              <h4 class="exp-card__role">Built and launched the mobile app</h4>
+              <h4 class="exp-card__role">Founder</h4>
               <p class="exp-card__location">United Arab Emirates</p>
               <ul class="exp-card__bullets">
                 <li>


### PR DESCRIPTION
## Changes

- **About section**: Moved the Outfitr/NomNom paragraph to second position (before the AWS paragraph), so the narrative leads with what the portfolio is actually focused on — co-founding
- **ShareAllBooks exp card**: Changed role from "Built and launched the mobile app" → **"Founder"** — matches the bullet points and is more accurate/impactful