### PR TITLE
copy(about): drop co-founder name from Outfitr blurb

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,9 +214,9 @@
             <p class="about__paragraph">
               I'm co-founding
               <a href="https://outfitr.net/" target="_blank" rel="noopener noreferrer" class="text-link">Outfitr</a>
-              with Yuni Kim — wardrobe-first social fashion that plans what to wear today from clothes you already own,
-              layers friend social on top for virtual try-ons, and owns the daily getting-dressed ritual instead of
-              competing in the shopping moment. I also co-founded
+              — wardrobe-first social fashion that plans what to wear today from clothes you already own, layers friend
+              social on top for virtual try-ons, and owns the daily getting-dressed ritual instead of competing in the
+              shopping moment. I also co-founded
               <a href="https://nomnom.cc" target="_blank" rel="noopener noreferrer" class="text-link">NomNom</a>, a
               dining-hall delivery marketplace for UCSD's ~40k students, building both the student and rider apps solo
               before UCSD admin shut us down — which taught us that products requiring institutional permission don't


### PR DESCRIPTION
## Summary
- Removes "with Yuni Kim" from the About paragraph's Outfitr sentence.
- Paragraph now reads: "I'm co-founding Outfitr — wardrobe-first social fashion that plans what to wear today..."

## Test plan
- [ ] About paragraph reads naturally with the em-dash flowing directly from "Outfitr"
- [ ] No layout shift in the About section