### PR TITLE
fix(projects): properly resolve conflict markers, restore newer content

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,10 +166,11 @@
             <span class="hero__line hero__line--last">Bhandari</span>
           </h1>
           <p class="hero__subtitle">
-            <span class="hero__subtitle-line hero__subtitle-line--lede"
-              >ML Researcher @ UCSD · SDE Intern @ AWS (returning '26) · Building NomNom and Outfitr</span
+            <span class="hero__subtitle-line hero__subtitle-line--lede">Co-founder, Outfitr · CS + ML @ UCSD</span>
+            <span class="hero__subtitle-line"
+              >Shipped my first app at 16. <span class="hero__upright">AWS</span>
+              <span class="hero__upright">SWE</span> Intern at 18. Now, building the social layer for fashion.</span
             >
-            <span class="hero__subtitle-line">Machine learning, mobile systems, and public-interest software</span>
           </p>
         </div>
       </section>
@@ -211,6 +212,18 @@
             </p>
 
             <p class="about__paragraph">
+              I'm co-founding
+              <a href="https://outfitr.net/" target="_blank" rel="noopener noreferrer" class="text-link">Outfitr</a>
+              — wardrobe-first social fashion that plans what to wear today from clothes you already own, layers friend
+              social on top for virtual try-ons, and owns the daily getting-dressed ritual instead of competing in the
+              shopping moment. I also co-founded
+              <a href="https://nomnom.cc" target="_blank" rel="noopener noreferrer" class="text-link">NomNom</a>, a
+              dining-hall delivery marketplace for UCSD's ~40k students, building both the student and rider apps solo
+              before UCSD admin shut us down — which taught us that products requiring institutional permission don't
+              scale.
+            </p>
+
+            <p class="about__paragraph">
               Last summer, I was a Software Development Engineer (SDE) Intern on the AWS Hyperplane team, and I'll be
               returning this coming summer. I shipped internal frontend and backend tools adopted across the team,
               spanning a CLI command generator that reduced on&#8209;call manual effort by ~75% and a Java/Python AWS
@@ -218,46 +231,19 @@
             </p>
 
             <p class="about__paragraph">
-              I'm currently building
-              <a href="https://nomnom.cc" target="_blank" rel="noopener noreferrer" class="text-link">NomNom</a>, a UCSD
-              delivery product, and
-              <a href="https://outfitr.net/" target="_blank" rel="noopener noreferrer" class="text-link">Outfitr</a>, an
-              AI-native fashion discovery product across mobile, backend, and experimentation systems.
-            </p>
-
-            <p class="about__paragraph">
-              I also build for public impact:
-              <a href="https://nyaaywatch.in" target="_blank" rel="noopener noreferrer" class="text-link">NyaayWatch</a>
-              turns Indian court-system snapshots into public evidence surfaces, and
-              <a href="https://shareallbooks.com/" target="_blank" rel="noopener noreferrer" class="text-link"
-                >ShareAllBooks</a
-              >
-              was a UAE book-sharing app
-              <a
-                href="https://www.khaleejtimes.com/uae/dubai-student-creates-app-for-free-exchange-of-books"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="text-link"
-                >featured in national press</a
-              >
-              that reached
-              <span data-stat="shareallbooks-downloads" data-stat-format="compact-plus">2K+</span> downloads and 1,500+
-              book transactions.
-            </p>
-
-            <p class="about__paragraph">
-              Through
+              I also build for public impact. Through
               <a href="https://tritonse.github.io/" target="_blank" rel="noopener noreferrer" class="text-link"
                 >Triton Software Engineering</a
-              >, I build full-stack features for the David Brower Center using TypeScript, React, Node.js, Prisma, and
-              Postgres, which keeps me sharp in team environments as well as independent builds.
+              >, I've contributed to pro-bono projects for nonprofits, including a mental health awareness app for
+              Psyches of Color and a nonprofit relationship visualization database for the
+              <a href="https://browercenter.org/" target="_blank" rel="noopener noreferrer" class="text-link"
+                >David Brower Center</a
+              >. I'm also proud of
+              <a href="https://nyaaywatch.in" target="_blank" rel="noopener noreferrer" class="text-link">NyaayWatch</a
+              >, an open-source platform that turns Indian court-system data into public evidence surfaces.
             </p>
 
             <div class="about__stats">
-              <div class="about__stat">
-                <span class="about__stat-number" data-target="3.9">3.9</span>
-                <span class="about__stat-label">GPA @ UCSD</span>
-              </div>
               <div class="about__stat">
                 <span
                   class="about__stat-number"
@@ -291,29 +277,11 @@
           <p class="section-kicker section-kicker--light">Where I've shipped</p>
           <h2 class="experience__heading">Experience</h2>
           <p class="section-intro section-intro--light">
-            Currently co-founding two products. Previously shipped production software at AWS and nonprofits.
+            Co-founding Outfitr. Building the full stack solo. Previously: AWS Hyperplane, two UCSD ML labs, NomNom.
           </p>
         </div>
         <div class="experience__track-wrapper">
           <div class="experience__track">
-            <!-- Card: NomNom -->
-            <article class="exp-card">
-              <span class="exp-card__date">Sep 2025 – Present</span>
-              <h3 class="exp-card__company">NomNom</h3>
-              <h4 class="exp-card__role">Co-founder</h4>
-              <p class="exp-card__location">San Diego, CA</p>
-              <ul class="exp-card__bullets">
-                <li>
-                  Building a two-sided dining-hall delivery marketplace for UCSD's ~40k students — separate React Native
-                  apps for students and riders, with Stripe payments, live order tracking, and UCSD-only SSO.
-                </li>
-                <li>
-                  Shipping the Student and Rider apps in closed beta; handling product, engineering, and operations
-                  end-to-end alongside my co-founder.
-                </li>
-              </ul>
-            </article>
-
             <!-- Card: Outfitr -->
             <article class="exp-card">
               <span class="exp-card__date">Feb 2026 – Present</span>
@@ -322,12 +290,62 @@
               <p class="exp-card__location">Remote</p>
               <ul class="exp-card__bullets">
                 <li>
-                  Building a swipe-based AI outfit discovery app that assembles shoppable looks across retailers —
-                  discover and shop complete outfits instead of single items, one swipe at a time.
+                  Wardrobe-first social fashion: import your closet from selfies (AI garment extraction), plan daily
+                  outfits from what you own, and layer social on top where friends virtually try on each other's
+                  wardrobes. I'm writing every line of code: React Native / Expo app, Fastify BFF, mirror-selfie
+                  ingestion pipeline, outfit ranking engine, VTO orchestration, and AWS infrastructure.
                 </li>
                 <li>
-                  Architecting a TypeScript monorepo across mobile app, catalog ingestion workers, AI virtual try-on
+                  Architecting a TypeScript monorepo across mobile app, closet-import workers, AI virtual try-on
                   pipeline, and an experimentation layer for personalisation. iOS in TestFlight private beta.
+                </li>
+              </ul>
+            </article>
+
+            <!-- Card: SVCL Research -->
+            <article class="exp-card">
+              <span class="exp-card__date">Apr 2026 – Present</span>
+              <h3 class="exp-card__company">UC San Diego · SVCL</h3>
+              <h4 class="exp-card__role">Undergraduate Researcher</h4>
+              <p class="exp-card__location">San Diego, CA</p>
+              <ul class="exp-card__bullets">
+                <li>
+                  Researching knowledge distillation of embedding models for retrieval-augmented generation in Prof.
+                  Nuno Vasconcelos'
+                  <a
+                    href="http://www.svcl.ucsd.edu/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-link text-link--light"
+                    >Statistical Visual Computing Laboratory (SVCL)</a
+                  >.
+                </li>
+                <li>
+                  Training compact retrievers to match large teacher model quality, evaluated across BEIR benchmarks.
+                </li>
+              </ul>
+            </article>
+
+            <!-- Card: ACT Lab Research -->
+            <article class="exp-card">
+              <span class="exp-card__date">Mar 2026 – Present</span>
+              <h3 class="exp-card__company">UC San Diego · ACT Lab</h3>
+              <h4 class="exp-card__role">Undergraduate Researcher</h4>
+              <p class="exp-card__location">San Diego, CA</p>
+              <ul class="exp-card__bullets">
+                <li>
+                  Researching KV cache acceleration for multi-agent LLM inference in Prof. Hadi Esmaeilzadeh's
+                  <a
+                    href="http://act-lab.org/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-link text-link--light"
+                    >Alternative Computing Technologies (ACT) Lab</a
+                  >.
+                </li>
+                <li>
+                  Reducing time-to-first-token by sharing cached key-value computations across agents with overlapping
+                  context.
                 </li>
               </ul>
             </article>
@@ -351,6 +369,24 @@
                   Engineered a backend event-publishing service that unified patching visibility across 14 EC2 cluster
                   groups, reducing root-cause detection time and accelerating cross-team debugging during availability
                   incidents.
+                </li>
+              </ul>
+            </article>
+
+            <!-- Card: NomNom -->
+            <article class="exp-card">
+              <span class="exp-card__date">Sep 2025 – Mar 2026</span>
+              <h3 class="exp-card__company">NomNom</h3>
+              <h4 class="exp-card__role">Co-founder</h4>
+              <p class="exp-card__location">San Diego, CA</p>
+              <ul class="exp-card__bullets">
+                <li>
+                  Building a two-sided dining-hall delivery marketplace for UCSD's ~40k students — separate React Native
+                  apps for students and riders, with Stripe payments, live order tracking, and UCSD-only SSO.
+                </li>
+                <li>
+                  Shipping the Student and Rider apps in closed beta; handling product, engineering, and operations
+                  end-to-end alongside my co-founder.
                 </li>
               </ul>
             </article>
@@ -381,7 +417,7 @@
             <article class="exp-card">
               <span class="exp-card__date">Aug 2023 – Sep 2024</span>
               <h3 class="exp-card__company">ShareAllBooks</h3>
-              <h4 class="exp-card__role">Built and launched the mobile app</h4>
+              <h4 class="exp-card__role">Founder</h4>
               <p class="exp-card__location">United Arab Emirates</p>
               <ul class="exp-card__bullets">
                 <li>
@@ -417,7 +453,7 @@
           <!-- Project images (stacked, crossfaded) -->
           <div class="projects__images" aria-hidden="true">
             <img
-              src="img/nomnom.png?v=2"
+              src="img/outfitr-live.png?v=1"
               alt=""
               class="projects__img"
               data-project="0"
@@ -425,7 +461,7 @@
               decoding="async"
             />
             <img
-              src="img/outfitr-live.png?v=1"
+              src="img/nomnom.png?v=2"
               alt=""
               class="projects__img"
               data-project="1"
@@ -481,15 +517,53 @@
 
             <p class="projects__tier-label">Building now</p>
 
-            <!-- 1. NomNom -->
+            <!-- 1. Outfitr -->
             <article class="proj-card proj-card--featured" data-project="0">
-              <h3 class="proj-card__title">NomNom</h3>
+              <h3 class="proj-card__title">Outfitr</h3>
               <p class="proj-card__metric">
-                Co-founder · Student + Rider apps in closed beta · Targeting ~40k UCSD students · Sep 2025 – present
+                Co-founder & CTO · Solo engineer, full stack · iOS TestFlight · Wardrobe data layer + daily outfit
+                engine · AI virtual try-on
               </p>
               <p class="proj-card__desc">
-                Two-sided mobile marketplace: students order dining-hall meals, verified UCSD couriers deliver.
-                Dining-hall food, on demand for 40k students.
+                Fashion apps serve the shopping moment — people shop 3× a month. Outfitr owns the daily ritual of
+                getting dressed instead. Wardrobe-first social fashion: your closet is the primary surface — Outfitr
+                plans what to wear today from clothes you already own, then layers social on top with friends virtually
+                trying on each other's wardrobes. Once your closet data is in and your friend graph is there, switching
+                costs are real. Discovery and affiliate revenue are downstream consequences, not the product.
+              </p>
+              <ul class="proj-card__bullets">
+                <li>TypeScript monorepo: mobile app, API, ingestion workers, shared SDK.</li>
+                <li>
+                  Backend for catalog normalization, outfit composition, ranking, and bundle generation across
+                  merchants.
+                </li>
+                <li>AI virtual try-on with async job orchestration, provider abstraction, and privacy-aware media.</li>
+                <li>
+                  Mirror-selfie import pipeline for wardrobe onboarding (photo library → AI garment extraction →
+                  closet).
+                </li>
+                <li>Telemetry + experimentation layer for personalization and A/B-ing the swipe flow.</li>
+              </ul>
+              <div class="proj-card__tech">
+                <span>TypeScript</span><span>React Native</span><span>AI</span><span>AWS</span>
+              </div>
+              <a href="https://outfitr.net/" target="_blank" rel="noopener noreferrer" class="proj-card__link"
+                >Visit outfitr.net →</a
+              >
+            </article>
+
+            <p class="projects__tier-label">Prior work</p>
+
+            <!-- 2. NomNom -->
+            <article class="proj-card" data-project="1">
+              <h3 class="proj-card__title">NomNom</h3>
+              <p class="proj-card__metric">
+                Co-founder · Student + Rider apps in closed beta · Targeting ~40k UCSD students · Sep 2025 – Mar 2026
+              </p>
+              <p class="proj-card__desc">
+                Two-sided dining-hall delivery marketplace for UCSD's ~40k students. Built and shipped both the student
+                and rider apps solo. Shut down by UCSD administration — taught us that products requiring institutional
+                permission don't scale.
               </p>
               <ul class="proj-card__bullets">
                 <li>Built dual React Native apps (Student + Rider) in a TypeScript monorepo.</li>
@@ -506,35 +580,6 @@
                 >Visit nomnom.cc →</a
               >
             </article>
-
-            <!-- 2. Outfitr -->
-            <article class="proj-card proj-card--featured" data-project="1">
-              <h3 class="proj-card__title">Outfitr</h3>
-              <p class="proj-card__metric">
-                Co-founder · iOS TestFlight private beta · Multi-retailer catalog ingestion · AI virtual try-on
-              </p>
-              <p class="proj-card__desc">
-                Swipe-based mobile app that builds shoppable outfits across retailers. Discover and shop complete looks
-                instead of single items — one swipe, one tap, full outfit.
-              </p>
-              <ul class="proj-card__bullets">
-                <li>TypeScript monorepo: mobile app, API, ingestion workers, shared SDK.</li>
-                <li>
-                  Backend for catalog normalization, outfit composition, ranking, and bundle generation across
-                  merchants.
-                </li>
-                <li>AI virtual try-on with async job orchestration, provider abstraction, and privacy-aware media.</li>
-                <li>Telemetry + experimentation layer for personalization and A/B-ing the swipe flow.</li>
-              </ul>
-              <div class="proj-card__tech">
-                <span>TypeScript</span><span>React Native</span><span>AI</span><span>AWS</span>
-              </div>
-              <a href="https://outfitr.net/" target="_blank" rel="noopener noreferrer" class="proj-card__link"
-                >Visit outfitr.net →</a
-              >
-            </article>
-
-            <p class="projects__tier-label">Prior work</p>
 
             <!-- 3. ShareAllBooks -->
             <article class="proj-card" data-project="3">
@@ -667,10 +712,11 @@
       <section id="contact" class="scene scene--contact">
         <div class="contact__inner">
           <p class="contact__status">
-            <span class="contact__status-line contact__status-line--primary"
-              >Looking for full-time roles from April 2027</span
+            <span class="contact__status-line contact__status-line--primary">Full-time on Outfitr through 2026.</span>
+            <span class="contact__status-line">Open to full-time SWE roles from April 2027.</span>
+            <span class="contact__status-line"
+              >Open to conversations with investors, retail partners, and early users of Outfitr.</span
             >
-            <span class="contact__status-line">Open to conversations about NomNom &amp; Outfitr</span>
           </p>
           <p class="contact__tagline">Let's build something people want</p>
           <a
@@ -680,7 +726,7 @@
             class="contact__cta"
             >Book a 20-minute chat →</a
           >
-          <a href="mailto:rubhandari@ucsd.edu" class="contact__email">rubhandari@ucsd.edu</a>
+          <a href="mailto:hello@rudrakshbhandari.com" class="contact__email">hello@rudrakshbhandari.com</a>
           <div class="contact__socials">
             <a
               href="https://www.linkedin.com/in/rudrakshbhandari"


### PR DESCRIPTION
## Summary
- Removes all git conflict markers from `index.html` properly
- Keeps the `origin/main` side of every conflict (the newer content)
- Restores the updated Outfitr description in the Experience section
- Restores the updated Outfitr project card description  
- Drops the stale duplicate old Outfitr project card that was in the HEAD side
- Fixes the NomNom description trailing marker

Previous fix attempt (#635) used `--theirs` during rebase which pulled in old branch content and wiped all recent copy changes. This restores everything correctly.