### PR TITLE
feat(health): per-sample dots on HR timeline + copy/format cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@ The format is based on Keep a Changelog and this project uses date-based release
 - Replaced Vercel hosting/analytics hooks with GitHub Pages deployment scaffolding plus Cloudflare and GA4 configuration.
 - Removed the lingering Vercel custom-domain aliases and Git integration for `mywebsite` so production is unambiguously GitHub Pages + Cloudflare.
 
+## [2026-05-20]
+
+### Added
+
+- Per-sample dots on the intraday Heart Rate Timeline so gaps in Oura's recording are visible. Long flat segments between two far-apart dots now read as "no data here," not as interpolated truth.
+
+### Changed
+
+- Tightened NomNom and Outfitr project card copy to plainer descriptions; dropped the cute one-liners.
+- Prettier line-wrap pass on `index.html` (no behavior change).
+
 ## [2026-02-27]
 
 ### Added

--- a/health/index.html
+++ b/health/index.html
@@ -729,6 +729,11 @@
         fill: rgba(94, 234, 212, 0.14);
       }
 
+      .timeline-point {
+        fill: #5eead4;
+        pointer-events: none;
+      }
+
       .chart-tooltip {
         position: fixed;
         z-index: 100;
@@ -1578,6 +1583,7 @@
                 <g id="hr-grid"></g>
                 <path id="heart-rate-fill" class="timeline-fill" d=""></path>
                 <path id="heart-rate-line" class="timeline-line" d=""></path>
+                <g id="hr-points"></g>
                 <line
                   id="hr-tracking-line"
                   class="hr-tracking-line"

--- a/js/health.js
+++ b/js/health.js
@@ -675,6 +675,19 @@ function renderHeartRateTimeline(series, data) {
   line.setAttribute('d', linePath);
   fill.setAttribute('d', fillPath);
 
+  // Render a dot at each real sample so gaps in Oura's recording are visible —
+  // long flat segments between two far-apart dots = no data, not interpolated truth.
+  // r scales down for dense datasets so 200-point sleep windows don't look like a thick bar.
+  const pointsEl = document.getElementById('hr-points');
+  if (pointsEl) {
+    const dotRadius = points.length > 400 ? 1.4 : points.length > 150 ? 1.8 : 2.2;
+    pointsEl.innerHTML = points
+      .map(
+        p => `<circle class="timeline-point" cx="${p.x.toFixed(2)}" cy="${p.y.toFixed(2)}" r="${dotRadius}"></circle>`
+      )
+      .join('');
+  }
+
   axisY.innerHTML = `
     <text x="${marginLeft - 8}" y="${bottom}" class="timeline-axis-label" text-anchor="end">${minBpm}</text>
     <text x="${marginLeft - 8}" y="${(top + bottom) / 2}" class="timeline-axis-label" text-anchor="end">${midBpm}</text>


### PR DESCRIPTION
## Summary

**Health Dashboard**
- Render a small SVG circle at each real Oura sample on the intraday Heart Rate Timeline. Dense areas form a textured chain (real high-frequency samples); sparse stretches show clearly separated dots with thin interpolation lines between — so gaps in Oura's recording are visible instead of looking like smooth fake data.
- Dot radius scales with point count (1.4 / 1.8 / 2.2px) so 200-point sleep windows don't render as a thick teal bar.

**Portfolio Projects**
- Tightened NomNom + Outfitr card copy to plainer descriptions; dropped the cute one-liners.
- Prettier line-wrap pass on `index.html` (no behavior change).

## Pre-Landing Review

Reviewed manually — diff is 19 net lines, frontend-only, additive.

- `innerHTML` usage in `js/health.js:684` interpolates only numeric values from `points.map` (`p.x.toFixed(2)`, `p.y.toFixed(2)`, `dotRadius`). No user-controlled strings → no XSS risk.
- `pointer-events: none` on dots — existing hover tracking and tracking-line behavior unaffected.
- `if (pointsEl)` guard means missing `#hr-points` element no-ops gracefully.
- Backwards compatible: line + fill paths unchanged.

No issues found.

## Verification

- Local preview at `http://localhost:8765/health/` confirmed visually:
  - Dense areas: textured chain of dots = real samples.
  - Sparse stretches: clearly separated dots with thin connecting line = "no data here".
- Prettier check passes.

## Test plan

- [ ] Visual check on production: dots visible on chart, hover tracking still works, no console errors.
- [ ] Mobile view: dots scale correctly with responsive viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)