### PR TITLE
feat(health): rolling 24h HR Timeline ending at the latest sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The format is based on Keep a Changelog and this project uses date-based release
 
 ### Changed
 
-- Heart Rate Timeline X-axis is now pinned to a fixed PT 00:00 → 24:00 window with labels at 12 AM / 6 AM / 12 PM / 6 PM / 12 AM, instead of auto-fitting to whatever range the data happens to cover. Days with partial coverage (e.g., "today" before sunset) show empty space on the right — that's the truthful behavior. All chart time labels now render in Pacific time regardless of viewer timezone so axis labels match data positions.
+- Heart Rate Timeline now shows a **rolling 24h window ending at the latest sample** instead of a PT calendar day. The latest data point anchors the right edge; the chart extends 24h to the left. At 3 PM PT that means last night's sleep + today's awake hours so far — always-full chart, no waiting for the day to fill in. Fetch pipeline filters samples to the same rolling window so the JSON payload matches the chart's range. All chart time labels render in Pacific time regardless of viewer timezone so axis labels match data positions.
 
 ### Fixed
 

--- a/js/health.js
+++ b/js/health.js
@@ -619,25 +619,16 @@ function formatTime(iso) {
 }
 
 /**
- * Given a UTC ISO timestamp known to fall on a PT calendar day,
- * return the UTC ms of that day's PT midnight (start) and start + 24h (end).
- * DST-correct because the offset is derived from the sample's own PT hour-of-day,
- * not a hardcoded assumption.
- * @param {string} sampleIsoUtc
+ * Rolling 24h window ending at the latest sample's timestamp.
+ * Anchoring to the actual data (not "today PT midnight") keeps the chart
+ * full of data right up to the right edge — last night's sleep plus today
+ * so far, instead of a "today" view with an empty afternoon.
+ * @param {Array<{t: string}>} series - chronologically sorted
  * @returns {{ start: number, end: number }}
  */
-function getPtDayBoundsMs(sampleIsoUtc) {
-  const sample = new Date(sampleIsoUtc);
-  const hms = sample.toLocaleString('en-GB', {
-    timeZone: 'America/Los_Angeles',
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-    hour12: false,
-  });
-  const [hh, mm, ss] = hms.split(':').map(Number);
-  const start = sample.getTime() - (hh * 3600 + mm * 60 + ss) * 1000;
-  return { start, end: start + 86400000 };
+function getRolling24hBounds(series) {
+  const end = new Date(series[series.length - 1].t).getTime();
+  return { start: end - 86400000, end };
 }
 
 /**
@@ -685,11 +676,11 @@ function renderHeartRateTimeline(series, data) {
   const rangeBpm = Math.max(maxBpm - minBpm, 1);
   const midBpm = Math.round((minBpm + maxBpm) / 2);
 
-  // Pin the X-axis to the full PT calendar day (00:00 → 24:00 PT) so empty
-  // hours read as "no data here" instead of the chart squishing to whatever
-  // window the data happens to cover. For "today" this means the right side
-  // is intentionally empty until more samples arrive.
-  const { start: timeStart, end: timeEnd } = getPtDayBoundsMs(series[0].t);
+  // Rolling 24h window ending at the latest sample. The latest data point
+  // sits at the right edge; the chart extends 24h to the left of that. So
+  // at 3 PM you see last night's sleep + today's awake hours — not a
+  // "today" view with an empty afternoon waiting to fill in.
+  const { start: timeStart, end: timeEnd } = getRolling24hBounds(series);
   const timeRange = Math.max(timeEnd - timeStart, 1);
   const points = series.map(point => {
     const t = new Date(point.t).getTime();
@@ -889,8 +880,11 @@ function renderHeartRateTimeline(series, data) {
   if (latestEl) latestEl.textContent = data.heartRateLatestBpm !== null ? `${data.heartRateLatestBpm} bpm` : '--';
 
   if (footer) {
-    const sourceDay = data.heartRateSeriesDay ? `Source day: ${data.heartRateSeriesDay}` : 'Intraday trend';
-    footer.textContent = `${sourceDay} • ${series.length} points`;
+    // Rolling 24h window — anchor the footer to the latest sample's time
+    // so the user can tell at a glance how fresh the chart is.
+    const latestT = series.length > 0 ? series[series.length - 1].t : null;
+    const through = latestT ? `Last 24h through ${formatTime(latestT)}` : 'Last 24h';
+    footer.textContent = `${through} • ${series.length} points`;
   }
 }
 

--- a/scripts/fetch_oura_and_write_json.mjs
+++ b/scripts/fetch_oura_and_write_json.mjs
@@ -994,11 +994,18 @@ async function main() {
     const readinessContributors = readinessData?.contributors || {};
     const activityContributors = activityData?.contributors || {};
 
-    // Heart rate: timeline for primary day only (PT), capped for public JSON size.
-    const hrNormalized = heartRateRaw
-      .map(normalizeHeartRatePoint)
-      .filter(Boolean)
-      .filter(p => getPtYmdFromTimestamp(p.timestamp) === dataDay);
+    // Heart rate: rolling 24h window ending at the most recent sample.
+    // Chosen over a PT calendar day so the chart always shows the user's actual
+    // last day of activity — at 3 PM PT, that's last night's sleep + today so far,
+    // not a "today" view that's mostly empty.
+    const hrAll = heartRateRaw.map(normalizeHeartRatePoint).filter(Boolean);
+    hrAll.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
+    const latestMs = hrAll.length > 0 ? new Date(hrAll[hrAll.length - 1].timestamp).getTime() : 0;
+    const rollingStartMs = latestMs - 24 * 60 * 60 * 1000;
+    const hrNormalized = hrAll.filter(p => {
+      const ms = new Date(p.timestamp).getTime();
+      return ms >= rollingStartMs && ms <= latestMs;
+    });
     const heartRateSeries = downsampleSeries(hrNormalized, HR_TIMELINE_MAX_POINTS);
     const heartRateStats =
       heartRateSeries.length > 0


### PR DESCRIPTION
## Summary

Replaces PR #657's PT-calendar-day window with a **rolling 24h window ending at the latest sample**. At 3 PM PT the chart now shows last night's sleep + today's awake hours so far, instead of a "today" view with an empty afternoon.

Both ends of the pipeline change:

**`scripts/fetch_oura_and_write_json.mjs`**
- Replaces the PT-day filter (`getPtYmdFromTimestamp(p.timestamp) === dataDay`) with a rolling 24h filter: find the latest sample, keep everything within 24h before it.
- The 48h fetch window from PR #655 still upstreams enough data to cover the rolling window even if you check at 11 PM.

**`js/health.js`**
- `getPtDayBoundsMs` → `getRolling24hBounds(series)`. End = latest sample's timestamp; start = end − 24h.
- Chart footer changes from `Source day: 2026-05-20` to `Last 24h through 3:13 PM`. Latest time is visible at a glance.
- Fill-path-closes-at-actual-data-range fix from PR #657 is retained — partial windows don't paint phantom hours.
- 5 X-axis labels at 6h intervals computed from the rolling bounds (e.g. `3:13 PM / 9:13 PM / 3:13 AM / 9:13 AM / 3:13 PM`). Labels track the latest sample rather than being fixed to midnight.

## Local verification

Chart now shows the right edge anchored to the latest sample (3:13 PM PT in current data), with X-axis labels stepping back in 6h intervals to the same time yesterday. Left side currently still empty in the local preview because production JSON hasn't re-run with the new fetch filter yet — that resolves on the first oura-update.yml run after merge.

## Test plan

- [ ] Force-trigger `oura-update.yml` after merge.
- [ ] Confirm new `oura_public.json` has samples spanning ~24h ending at the latest sample (not just one PT day).
- [ ] Visual check on `rudrakshbhandari.com/health`: chart full width, right edge at latest sample, footer says "Last 24h through HH:MM".

🤖 Generated with [Claude Code](https://claude.com/claude-code)