### PR TITLE
fix(health): add date to HR Timeline footer

### DIFF
--- a/js/health.js
+++ b/js/health.js
@@ -880,10 +880,20 @@ function renderHeartRateTimeline(series, data) {
   if (latestEl) latestEl.textContent = data.heartRateLatestBpm !== null ? `${data.heartRateLatestBpm} bpm` : '--';
 
   if (footer) {
-    // Rolling 24h window — anchor the footer to the latest sample's time
-    // so the user can tell at a glance how fresh the chart is.
+    // Rolling 24h window — anchor the footer to the latest sample's full
+    // date + time so the user can tell at a glance how fresh the chart is
+    // without having to guess which day "12:36 PM" referred to.
     const latestT = series.length > 0 ? series[series.length - 1].t : null;
-    const through = latestT ? `Last 24h through ${formatTime(latestT)}` : 'Last 24h';
+    let through = 'Last 24h';
+    if (latestT) {
+      const datePart = new Date(latestT).toLocaleDateString('en-US', {
+        timeZone: 'America/Los_Angeles',
+        weekday: 'short',
+        month: 'short',
+        day: 'numeric',
+      });
+      through = `Last 24h through ${datePart}, ${formatTime(latestT)} PT`;
+    }
     footer.textContent = `${through} • ${series.length} points`;
   }
 }


### PR DESCRIPTION
## Summary

`Last 24h through 12:36 PM` was ambiguous — at 1 AM the next day, you'd see "Last 24h through 12:36 PM" with no way to tell whether it's today or yesterday.

Now: **`Last 24h through Thu, May 21, 12:36 PM PT • 1019 points`**

Adds weekday + month + day before the time, and a `PT` suffix so non-PT viewers don't have to guess the timezone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)