### PR TITLE
fix(contact): lead with Outfitr over full-time roles

### DIFF
--- a/index.html
+++ b/index.html
@@ -756,7 +756,7 @@
         <div class="contact__inner">
           <p class="contact__status">
             <span class="contact__status-line contact__status-line--primary"
-              >Building Outfitr. Open to investors, retail partners, and early users.</span
+              >Open to investors, retail partners, and early users of Outfitr.</span
             >
             <span class="contact__status-line">Also open to select full-time conversations from April 2027.</span>
           </p>

--- a/index.html
+++ b/index.html
@@ -756,11 +756,9 @@
         <div class="contact__inner">
           <p class="contact__status">
             <span class="contact__status-line contact__status-line--primary"
-              >Looking for full-time roles from April 2027</span
+              >Building Outfitr. Open to investors, retail partners, and early users.</span
             >
-            <span class="contact__status-line"
-              >Open to conversations with investors, retail partners, and early users of Outfitr.</span
-            >
+            <span class="contact__status-line">Also open to select full-time conversations from April 2027.</span>
           </p>
           <p class="contact__tagline">Let's build something people want</p>
           <a
@@ -768,7 +766,7 @@
             target="_blank"
             rel="noopener noreferrer"
             class="contact__cta"
-            >Book a 20-minute chat →</a
+            >Talk about Outfitr →</a
           >
           <a href="mailto:hello@rudrakshbhandari.com" class="contact__email">hello@rudrakshbhandari.com</a>
           <div class="contact__socials">


### PR DESCRIPTION
## Summary
- Flip the contact status so Outfitr / investor conversations lead, with full-time roles secondary.
- Update the CTA from "Book a 20-minute chat" to "Talk about Outfitr".

## Scope
Intentionally copy-only in the contact section. Dropped the earlier hero rewrite, proof pills, founder-proof section, and animation/layout changes.

## Validation
- Visual: contact primary line + CTA wording
