### PR TITLE
feat(stats): add about stats visibility toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -261,7 +261,7 @@
               using TypeScript, React, Node.js, Prisma, and Postgres.
             </p>
 
-            <div class="about__stats">
+            <div class="about__stats" data-stats-section>
               <div class="about__stat">
                 <span
                   class="about__stat-number"

--- a/js/config.js
+++ b/js/config.js
@@ -7,4 +7,5 @@ const IS_DEV_MODE = false;
 // Populate these values before enabling production analytics providers.
 window.SITE_CONFIG = Object.freeze({
   ga4MeasurementId: 'G-KJDJKDNYNG',
+  showAboutStats: false,
 });

--- a/js/stats.js
+++ b/js/stats.js
@@ -20,6 +20,16 @@
 
   const STATS_URL = '/stats_public.json';
 
+  function shouldShowAboutStats() {
+    return window.SITE_CONFIG?.showAboutStats !== false;
+  }
+
+  function applyStatsVisibility() {
+    const statsSection = document.querySelector('[data-stats-section]');
+    if (!statsSection) return;
+    statsSection.hidden = !shouldShowAboutStats();
+  }
+
   function floorToNiceNumber(value) {
     if (value < 1000) return Math.floor(value / 10) * 10;
     if (value < 10000) return Math.floor(value / 100) * 100;
@@ -84,6 +94,9 @@
   }
 
   async function loadStats() {
+    applyStatsVisibility();
+    if (!shouldShowAboutStats()) return;
+
     try {
       const response = await fetch(STATS_URL, { cache: 'no-store' });
       if (!response.ok) return;


### PR DESCRIPTION
## Summary
- add a `showAboutStats` toggle in `window.SITE_CONFIG`
- hide the about stats block when the toggle is false
- skip fetching `stats_public.json` while the block is hidden

## Validation
- `npm run check:syntax`
- `npx prettier --check index.html js/config.js js/stats.js`
- `git diff --check`
