### PR TITLE
fix: remove EC2 cluster count from experience copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -420,7 +420,7 @@
                   ~75% and improved incident response latency.
                 </li>
                 <li>
-                  Engineered a backend event-publishing service that unified patching visibility across 14 EC2 cluster
+                  Engineered a backend event-publishing service that unified patching visibility across EC2 cluster
                   groups, reducing root-cause detection time and accelerating cross-team debugging during availability
                   incidents.
                 </li>


### PR DESCRIPTION
## Summary
- remove the specific EC2 cluster-group count from the backend event-publishing experience bullet

## Validation
- git diff --check