### PR TITLE
chore(github): refresh contribution graph [2026-07-28]

### DIFF
--- a/github_contributions.json
+++ b/github_contributions.json
@@ -1,8 +1,8 @@
 {
   "username": "rudrakshbhandari",
   "year": 2026,
-  "total": 10683,
-  "lastUpdatedIso": "2026-07-27T09:34:33.917Z",
+  "total": 10711,
+  "lastUpdatedIso": "2026-07-28T09:17:35.655Z",
   "source": "github-contributions-api.jogruber.de",
   "contributions": [
     {
@@ -1042,14 +1042,13 @@
     },
     {
       "date": "2026-07-27",
-      "count": 10,
+      "count": 23,
       "level": 1
     },
     {
       "date": "2026-07-28",
-      "count": 0,
-      "level": 0,
-      "future": true
+      "count": 15,
+      "level": 1
     },
     {
       "date": "2026-07-29",


### PR DESCRIPTION
Automated refresh of github_contributions.json for the portfolio contribution graph.