### PR TITLE
chore(github): refresh contribution graph [2026-08-01]

### DIFF
--- a/github_contributions.json
+++ b/github_contributions.json
@@ -1,8 +1,8 @@
 {
   "username": "rudrakshbhandari",
   "year": 2026,
-  "total": 10790,
-  "lastUpdatedIso": "2026-07-31T09:21:07.677Z",
+  "total": 10807,
+  "lastUpdatedIso": "2026-08-01T09:03:11.339Z",
   "source": "github-contributions-api.jogruber.de",
   "contributions": [
     {
@@ -1062,14 +1062,13 @@
     },
     {
       "date": "2026-07-31",
-      "count": 7,
+      "count": 16,
       "level": 1
     },
     {
       "date": "2026-08-01",
-      "count": 0,
-      "level": 0,
-      "future": true
+      "count": 8,
+      "level": 1
     },
     {
       "date": "2026-08-02",


### PR DESCRIPTION
Automated refresh of github_contributions.json for the portfolio contribution graph.