### PR TITLE
chore(github): refresh contribution graph [2026-08-02]

### DIFF
--- a/github_contributions.json
+++ b/github_contributions.json
@@ -1,8 +1,8 @@
 {
   "username": "rudrakshbhandari",
   "year": 2026,
-  "total": 10807,
-  "lastUpdatedIso": "2026-08-01T09:03:11.339Z",
+  "total": 10900,
+  "lastUpdatedIso": "2026-08-02T09:04:26.088Z",
   "source": "github-contributions-api.jogruber.de",
   "contributions": [
     {
@@ -1047,12 +1047,12 @@
     },
     {
       "date": "2026-07-28",
-      "count": 32,
+      "count": 31,
       "level": 1
     },
     {
       "date": "2026-07-29",
-      "count": 27,
+      "count": 26,
       "level": 1
     },
     {
@@ -1067,14 +1067,13 @@
     },
     {
       "date": "2026-08-01",
-      "count": 8,
-      "level": 1
+      "count": 86,
+      "level": 2
     },
     {
       "date": "2026-08-02",
-      "count": 0,
-      "level": 0,
-      "future": true
+      "count": 17,
+      "level": 1
     },
     {
       "date": "2026-08-03",


### PR DESCRIPTION
Automated refresh of github_contributions.json for the portfolio contribution graph.