### PR TITLE
chore(github): refresh contribution graph [2026-08-05]

### DIFF
--- a/github_contributions.json
+++ b/github_contributions.json
@@ -1,8 +1,8 @@
 {
   "username": "rudrakshbhandari",
   "year": 2026,
-  "total": 11035,
-  "lastUpdatedIso": "2026-08-04T09:19:18.682Z",
+  "total": 11054,
+  "lastUpdatedIso": "2026-08-05T09:18:19.185Z",
   "source": "github-contributions-api.jogruber.de",
   "contributions": [
     {
@@ -1082,14 +1082,13 @@
     },
     {
       "date": "2026-08-04",
-      "count": 5,
+      "count": 20,
       "level": 1
     },
     {
       "date": "2026-08-05",
-      "count": 0,
-      "level": 0,
-      "future": true
+      "count": 4,
+      "level": 1
     },
     {
       "date": "2026-08-06",


### PR DESCRIPTION
Automated refresh of github_contributions.json for the portfolio contribution graph.