### PR TITLE
chore(github): refresh contribution graph [2026-08-07]

### DIFF
--- a/github_contributions.json
+++ b/github_contributions.json
@@ -1,8 +1,8 @@
 {
   "username": "rudrakshbhandari",
   "year": 2026,
-  "total": 11069,
-  "lastUpdatedIso": "2026-08-06T10:57:11.930Z",
+  "total": 11082,
+  "lastUpdatedIso": "2026-08-07T09:18:14.192Z",
   "source": "github-contributions-api.jogruber.de",
   "contributions": [
     {
@@ -1092,14 +1092,13 @@
     },
     {
       "date": "2026-08-06",
-      "count": 5,
+      "count": 9,
       "level": 1
     },
     {
       "date": "2026-08-07",
-      "count": 0,
-      "level": 0,
-      "future": true
+      "count": 9,
+      "level": 1
     },
     {
       "date": "2026-08-08",


### PR DESCRIPTION
Automated refresh of github_contributions.json for the portfolio contribution graph.