### PR TITLE
chore(github): refresh contribution graph [2026-08-08]

### DIFF
--- a/github_contributions.json
+++ b/github_contributions.json
@@ -1,8 +1,8 @@
 {
   "username": "rudrakshbhandari",
   "year": 2026,
-  "total": 11082,
-  "lastUpdatedIso": "2026-08-07T09:18:14.192Z",
+  "total": 11096,
+  "lastUpdatedIso": "2026-08-08T09:04:35.454Z",
   "source": "github-contributions-api.jogruber.de",
   "contributions": [
     {
@@ -1097,14 +1097,13 @@
     },
     {
       "date": "2026-08-07",
-      "count": 9,
+      "count": 17,
       "level": 1
     },
     {
       "date": "2026-08-08",
-      "count": 0,
-      "level": 0,
-      "future": true
+      "count": 6,
+      "level": 1
     },
     {
       "date": "2026-08-09",


### PR DESCRIPTION
Automated refresh of github_contributions.json for the portfolio contribution graph.