### PR TITLE
chore(github): refresh contribution graph [2026-08-09]

### DIFF
--- a/github_contributions.json
+++ b/github_contributions.json
@@ -1,8 +1,8 @@
 {
   "username": "rudrakshbhandari",
   "year": 2026,
-  "total": 11096,
-  "lastUpdatedIso": "2026-08-08T09:04:35.454Z",
+  "total": 11127,
+  "lastUpdatedIso": "2026-08-09T09:05:39.736Z",
   "source": "github-contributions-api.jogruber.de",
   "contributions": [
     {
@@ -1102,14 +1102,13 @@
     },
     {
       "date": "2026-08-08",
-      "count": 6,
+      "count": 28,
       "level": 1
     },
     {
       "date": "2026-08-09",
-      "count": 0,
-      "level": 0,
-      "future": true
+      "count": 9,
+      "level": 1
     },
     {
       "date": "2026-08-10",


### PR DESCRIPTION
Automated refresh of github_contributions.json for the portfolio contribution graph.