### PR TITLE
chore(github): refresh contribution graph [2026-08-13]

### DIFF
--- a/github_contributions.json
+++ b/github_contributions.json
@@ -1,8 +1,8 @@
 {
   "username": "rudrakshbhandari",
   "year": 2026,
-  "total": 11213,
-  "lastUpdatedIso": "2026-08-12T08:47:38.563Z",
+  "total": 11235,
+  "lastUpdatedIso": "2026-08-13T08:48:44.731Z",
   "source": "github-contributions-api.jogruber.de",
   "contributions": [
     {
@@ -1122,14 +1122,13 @@
     },
     {
       "date": "2026-08-12",
-      "count": 8,
+      "count": 22,
       "level": 1
     },
     {
       "date": "2026-08-13",
-      "count": 0,
-      "level": 0,
-      "future": true
+      "count": 8,
+      "level": 1
     },
     {
       "date": "2026-08-14",


### PR DESCRIPTION
Automated refresh of github_contributions.json for the portfolio contribution graph.