### PR TITLE
chore(github): refresh contribution graph [2026-08-14]

### DIFF
--- a/github_contributions.json
+++ b/github_contributions.json
@@ -1,8 +1,8 @@
 {
   "username": "rudrakshbhandari",
   "year": 2026,
-  "total": 11235,
-  "lastUpdatedIso": "2026-08-13T08:48:44.731Z",
+  "total": 11264,
+  "lastUpdatedIso": "2026-08-14T08:46:18.737Z",
   "source": "github-contributions-api.jogruber.de",
   "contributions": [
     {
@@ -1127,14 +1127,13 @@
     },
     {
       "date": "2026-08-13",
-      "count": 8,
+      "count": 28,
       "level": 1
     },
     {
       "date": "2026-08-14",
-      "count": 0,
-      "level": 0,
-      "future": true
+      "count": 9,
+      "level": 1
     },
     {
       "date": "2026-08-15",


### PR DESCRIPTION
Automated refresh of github_contributions.json for the portfolio contribution graph.