### PR TITLE
chore(github): refresh contribution graph [2026-08-15]

### DIFF
--- a/github_contributions.json
+++ b/github_contributions.json
@@ -1,8 +1,8 @@
 {
   "username": "rudrakshbhandari",
   "year": 2026,
-  "total": 11264,
-  "lastUpdatedIso": "2026-08-14T08:46:18.737Z",
+  "total": 11288,
+  "lastUpdatedIso": "2026-08-15T08:31:49.019Z",
   "source": "github-contributions-api.jogruber.de",
   "contributions": [
     {
@@ -1132,14 +1132,13 @@
     },
     {
       "date": "2026-08-14",
-      "count": 9,
+      "count": 25,
       "level": 1
     },
     {
       "date": "2026-08-15",
-      "count": 0,
-      "level": 0,
-      "future": true
+      "count": 8,
+      "level": 1
     },
     {
       "date": "2026-08-16",


### PR DESCRIPTION
Automated refresh of github_contributions.json for the portfolio contribution graph.