### PR TITLE
chore(github): refresh contribution graph [2026-08-16]

### DIFF
--- a/github_contributions.json
+++ b/github_contributions.json
@@ -1,8 +1,8 @@
 {
   "username": "rudrakshbhandari",
   "year": 2026,
-  "total": 11288,
-  "lastUpdatedIso": "2026-08-15T08:31:49.019Z",
+  "total": 11327,
+  "lastUpdatedIso": "2026-08-16T08:32:16.489Z",
   "source": "github-contributions-api.jogruber.de",
   "contributions": [
     {
@@ -1102,7 +1102,7 @@
     },
     {
       "date": "2026-08-08",
-      "count": 28,
+      "count": 27,
       "level": 1
     },
     {
@@ -1137,14 +1137,13 @@
     },
     {
       "date": "2026-08-15",
-      "count": 8,
+      "count": 39,
       "level": 1
     },
     {
       "date": "2026-08-16",
-      "count": 0,
-      "level": 0,
-      "future": true
+      "count": 9,
+      "level": 1
     },
     {
       "date": "2026-08-17",


### PR DESCRIPTION
Automated refresh of github_contributions.json for the portfolio contribution graph.