### PR TITLE
chore(github): refresh contribution graph [2026-08-17]

### DIFF
--- a/github_contributions.json
+++ b/github_contributions.json
@@ -1,8 +1,8 @@
 {
   "username": "rudrakshbhandari",
   "year": 2026,
-  "total": 11327,
-  "lastUpdatedIso": "2026-08-16T08:32:16.489Z",
+  "total": 11356,
+  "lastUpdatedIso": "2026-08-17T08:34:09.807Z",
   "source": "github-contributions-api.jogruber.de",
   "contributions": [
     {
@@ -1142,14 +1142,13 @@
     },
     {
       "date": "2026-08-16",
-      "count": 9,
+      "count": 32,
       "level": 1
     },
     {
       "date": "2026-08-17",
-      "count": 0,
-      "level": 0,
-      "future": true
+      "count": 6,
+      "level": 1
     },
     {
       "date": "2026-08-18",


### PR DESCRIPTION
Automated refresh of github_contributions.json for the portfolio contribution graph.